### PR TITLE
Error handling when multiple definitions are requested

### DIFF
--- a/language-service/language_service/controller/__init__.py
+++ b/language-service/language_service/controller/__init__.py
@@ -80,6 +80,7 @@ class DefinitionMultipleController(Resource):
                 word: [
                     definition.to_json()
                     for definition in get_definitions(language, word)
+                    if definition is not None
                 ]
                 for word in words
             }

--- a/language-service/language_service/service/definition/__init__.py
+++ b/language-service/language_service/service/definition/__init__.py
@@ -13,32 +13,7 @@ from language_service.service.definition.wiktionary import (
 
 def get_definitions(language, word):
     if language == "CHINESE":
-        wiktionary_definitions = get_wiktionary_definitions(language, word)
-
-        cedict_definition = get_cedict_definitions(word)
-        if cedict_definition:
-            print("Attaching cedict definition for %s" % word)
-            definitions = []
-            for definition in wiktionary_definitions:
-                # The CEDICT definitions are more focused than wiktionary so we should prefer them.
-                subdefinitions = (
-                    cedict_definition["definitions"]
-                    if "definitions" in cedict_definition
-                    else definition.subdefinitions
-                )
-
-                improved_definition = ChineseDefinition(
-                    subdefinitions=subdefinitions,
-                    tag=definition.tag,
-                    examples=definition.examples,
-                    pinyin=cedict_definition["pinyin"],
-                    simplified=cedict_definition["simplified"],
-                    traditional=cedict_definition["traditional"],
-                )
-                definitions.append(improved_definition)
-            return definitions
-        else:
-            return wiktionary_definitions
+        return get_chinese_definitions(word)
 
     elif language == "ENGLISH":
         return get_wiktionary_definitions(language, word)
@@ -48,3 +23,42 @@ def get_definitions(language, word):
 
     else:
         raise NotImplementedError("Unknown language requested: %s")
+
+
+def get_chinese_definitions(word):
+    wiktionary_definitions = get_wiktionary_definitions("CHINESE", word)
+    cedict_definition = get_cedict_definitions(word)
+
+    if wiktionary_definitions is not None and cedict_definition is not None:
+        print("CHINESE - Found wiktionary and cedict definitions for %s" % word)
+        definitions = []
+        for definition in wiktionary_definitions:
+            # The CEDICT definitions are more focused than wiktionary so we should prefer them.
+            subdefinitions = (
+                cedict_definition.subdefinitions
+                if cedict_definition.subdefinitions is not None
+                else definition.subdefinitions
+            )
+
+            improved_definition = ChineseDefinition(
+                subdefinitions=subdefinitions,
+                tag=definition.tag,
+                examples=definition.examples,
+                pinyin=cedict_definition.pinyin,
+                simplified=cedict_definition.simplified,
+                traditional=cedict_definition.traditional,
+            )
+            definitions.append(improved_definition)
+        return definitions
+
+    elif wiktionary_definitions is not None and cedict_definition is None:
+        print("CHINESE - Only found wiktionary definition for %s" % word)
+        return wiktionary_definitions
+
+    elif wiktionary_definitions is None and cedict_definition is not None:
+        print("CHINESE - Only found cedict definition for %s" % word)
+        return [cedict_definition]
+
+    else:
+        print("CHINESE - No definition found for %s" % word)
+        return None

--- a/language-service/language_service/service/definition/cedict/__init__.py
+++ b/language-service/language_service/service/definition/cedict/__init__.py
@@ -3,6 +3,7 @@ CEDICT is an open source Chinese dictionary.
 This class provides definitions
 """
 import json
+from language_service.dto import ChineseDefinition
 
 definitions = {}
 with open("content/cedict.json") as cedict:
@@ -13,6 +14,12 @@ with open("content/cedict.json") as cedict:
 
 def get_definitions(word):
     if word in definitions:
-        return definitions[word]
+        definition = definitions[word]
+        return ChineseDefinition(
+            subdefinitions=definition["definitions"],
+            pinyin=definition["pinyin"],
+            simplified=definition["simplified"],
+            traditional=definition["traditional"],
+        )
     else:
         return None

--- a/language-service/language_service/service/definition/wiktionary/__init__.py
+++ b/language-service/language_service/service/definition/wiktionary/__init__.py
@@ -10,7 +10,12 @@ parser = WiktionaryParser()
 
 
 def get_definitions(language, word):
-    response = parser.fetch(word, language)
+    try:
+        response = parser.fetch(word, language)
+    except Exception as e:
+        print("%s - Error fetching definition for %s" % (language, word))
+        print(e)
+        return None
 
     definitions = []
     for entry in response:


### PR DESCRIPTION
We don't want one bad lookup to fail the entire transaction. Instead, just don't return that one.