### PR TITLE
Request definitions in parallel

### DIFF
--- a/language-service/language_service/controller/__init__.py
+++ b/language-service/language_service/controller/__init__.py
@@ -57,7 +57,7 @@ class DefinitionController(Resource):
         if word is None or word == "":
             return {"error": "Word is required"}, 400
 
-        print("%s - Getting definition for %s" % (language, word))
+        print("Getting definition in %s for %s" % (language, word))
 
         try:
             definitions, _word = fetch_definitions(language, word)
@@ -88,7 +88,7 @@ class DefinitionMultipleController(Resource):
 
         words = request_json["words"]
 
-        print("%s - Getting definitions for %s" % (language, words))
+        print("Getting definitions in %s for %s" % (language, words))
 
         try:
             with Pool(10) as pool:
@@ -133,7 +133,7 @@ class DocumentController(Resource):
 
         text = request_json["text"]
 
-        print("%s - Getting words for %s" % (language, text))
+        print("Getting words in %s for %s" % (language, text))
 
         try:
             return [word.to_json() for word in tag(language, text)], 200

--- a/language-service/language_service/controller/__init__.py
+++ b/language-service/language_service/controller/__init__.py
@@ -93,11 +93,13 @@ class DefinitionMultipleController(Resource):
         try:
             with Pool(10) as pool:
                 returned_definitions = {}
+                # First we trigger the lookups here
                 for result in [
                     pool.apply_async(fetch_definitions, args=(language, word))
                     for word in words
                 ]:
                     try:
+                        # And then either the result is ready, or we time out.
                         definitions, word = result.get(5)
                         if definitions is not None:
                             print("Got definitions in %s for %s" % (language, word))

--- a/language-service/language_service/service/definition/cedict/__init__.py
+++ b/language-service/language_service/service/definition/cedict/__init__.py
@@ -21,7 +21,10 @@ class CEDICT:
     def get_definitions(self, word):
         # Lazy load definitions to make unit testing possible
         if self.definitions is None:
+            print("Loading CEDICT dictionary")
             self.load_dictionary()
+
+        print("CEDICT - Getting definitions in CHINESE for %s" % word)
 
         if word in self.definitions:
             definition = self.definitions[word]

--- a/language-service/language_service/service/definition/wiktionary/__init__.py
+++ b/language-service/language_service/service/definition/wiktionary/__init__.py
@@ -3,6 +3,7 @@ Scrapes Wiktionary for vocabulary definitions.
 At current moment, this only provides definitions in English for all languages.
 Wiktionary itself has definitions in many base languages, but the parser does not support it.
 """
+import traceback
 from wiktionaryparser import WiktionaryParser
 from language_service.dto import Definition
 
@@ -15,11 +16,13 @@ class Wiktionary:
         return self.parser.fetch(word, language)
 
     def get_definitions(self, language, word):
+        print("Wiktionary - getting definitions in %s for %s" % (language, word))
         try:
             response = self.fetch(word, language)
-        except Exception as e:
+        except Exception:
             print("%s - Error fetching definition for %s" % (language, word))
-            print(e)
+            stacktrace = traceback.format_exc()
+            print(stacktrace)
             return None
 
         definitions = []


### PR DESCRIPTION
Requesting definitions serially causes most requests to time out. They should be requested in parallel.