### PR TITLE
Bugfix: Keep word with request

### DIFF
--- a/language-service/language_service/service/definition/__init__.py
+++ b/language-service/language_service/service/definition/__init__.py
@@ -29,35 +29,36 @@ def get_definitions(language, word):
         raise NotImplementedError("Unknown language requested: %s")
 
 
-def fetch_definitions(language, word):
-    """
-    Helper method to handle getting and deserializing a single definition
-    Can't be a lambda because it must be picked to work with the thread pool
-    """
-    definitions = get_definitions(language, word)
-    return word, definitions
-
-
 def get_definitions_for_group(language, words):
+    """
+    Get definitions in parallel for multiple words
+    """
     with Pool(10) as pool:
         # First we trigger the lookups in parallel here
         requests = [
-            pool.apply_async(fetch_definitions, args=(language, word)) for word in words
+            (word, pool.apply_async(get_definitions, args=(language, word)))
+            for word in words
         ]
 
         # Then we get the results
         definitions = []
-        for result in requests:
+        for word, result in requests:
             try:
                 # And then either the result is ready, or we time out.
-                word, word_definitions = result.get(5)
+                word_definitions = result.get(5)
+
                 if word_definitions is not None:
                     logger.info("Got definitions in %s for %s" % (language, word))
                     definitions.append((word, word_definitions))
+
                 else:
                     logger.error("No definition in %s found for %s" % (language, word))
                     definitions.append((word, None))
+
             except MultiprocessingTimeoutError:
-                logger.error("Definition lookup timed out")
+                logger.error(
+                    "Definition lookup in %s timed out for %s" % (language, word)
+                )
                 definitions.append((word, None))
+
         return definitions


### PR DESCRIPTION
When logging that a word has timed out, we don't actually have the word to log. This keeps the word with the request callback object so that we can associate them.
This means we can log correctly and also won't reference "word" before assignment.