### PR TITLE
Bugfix: Multiple workers for web server

### DIFF
--- a/language-service/Dockerfile
+++ b/language-service/Dockerfile
@@ -31,4 +31,4 @@ COPY --from=builder /venv /venv
 COPY language_service /app/
 
 EXPOSE 8000
-CMD ["gunicorn", "LanguageService:app", "--log-level=debug", "-b", ":8000"]
+CMD ["gunicorn", "LanguageService:app", "--workers=4", "--log-level=debug", "-b", ":8000"]

--- a/language-service/language_service/controller/common.py
+++ b/language-service/language_service/controller/common.py
@@ -18,7 +18,7 @@ def check_authentication(method):
 
     @wraps(method)
     def authentication_checker(*args, **kwargs):
-        logger.info("Something is happening before the function is called.")
+        logger.info("Checking request authentication.")
 
         if (
             "Authorization" in request.headers


### PR DESCRIPTION
With only one worker, a long running request will make the server unresponsive. This means that the service will not respond to the health check, and then get restarted.