### PR TITLE
Redis connection uses TLS

### DIFF
--- a/infrastructure/kubernetes/language-service/deployment.yml
+++ b/infrastructure/kubernetes/language-service/deployment.yml
@@ -21,26 +21,11 @@ spec:
               secretKeyRef:
                 name: local-connection-token
                 key: local_connection_token
-          - name: CACHE_REDIS_PASSWORD
+          - name: CACHE_REDIS_URL
             valueFrom:
               secretKeyRef:
                 name: language-service-cache-credentials
-                key: password
-          - name: CACHE_REDIS_HOST
-            valueFrom:
-              secretKeyRef:
-                name: language-service-cache-credentials
-                key: host
-          - name: CACHE_REDIS_PORT
-            valueFrom:
-              secretKeyRef:
-                name: language-service-cache-credentials
-                key: port
-          - name: CACHE_REDIS_DB
-            valueFrom:
-              secretKeyRef:
-                name: language-service-cache-credentials
-                key: database
+                key: connection_string
         ports:
         - containerPort: 8000
         readinessProbe:

--- a/infrastructure/terraform/kubernetes_cluster_infrastructure/main.tf
+++ b/infrastructure/terraform/kubernetes_cluster_infrastructure/main.tf
@@ -91,11 +91,11 @@ resource "kubernetes_secret" "language_service_cache_credentials" {
   }
 
   data = {
-    username = digitalocean_database_cluster.language_service_cache.user
-    password = digitalocean_database_cluster.language_service_cache.password
-    host     = digitalocean_database_cluster.language_service_cache.private_host
-    port     = digitalocean_database_cluster.language_service_cache.port
-    database = digitalocean_database_cluster.language_service_cache.database
+    username          = digitalocean_database_cluster.language_service_cache.user
+    password          = digitalocean_database_cluster.language_service_cache.password
+    host              = digitalocean_database_cluster.language_service_cache.private_host
+    port              = digitalocean_database_cluster.language_service_cache.port
+    connection_string = "rediss://${digitalocean_database_cluster.language_service_cache.user}:${digitalocean_database_cluster.language_service_cache.password}@${digitalocean_database_cluster.language_service_cache.private_host}:${digitalocean_database_cluster.language_service_cache.port}/0"
   }
 }
 

--- a/language-service/language_service/LanguageService.py
+++ b/language-service/language_service/LanguageService.py
@@ -12,17 +12,21 @@ from language_service.controller.health import HealthController
 app = Flask(__name__)
 api = Api(app)
 
-config = {
-    "DEBUG": False,
-    "CACHE_TYPE": "redis",
-    "CACHE_DEFAULT_TIMEOUT": DAY,
-    "CACHE_KEY_PREFIX": "definitions",
-    "CACHE_REDIS_HOST": os.getenv("CACHE_REDIS_HOST", "localhost"),
-    "CACHE_REDIS_PORT": os.getenv("PORT", 6379),
-}
-if os.getenv("LOCAL", None) is None:
-    config["CACHE_REDIS_PASSWORD"] = os.getenv("CACHE_REDIS_PASSWORD")
-    config["CACHE_REDIS_DB"] = os.getenv("CACHE_REDIS_DB")
+# Configure caching:
+# If in production, use redis
+# Locally, don't cache
+# To test caching, just set the CACHE_REDIS_URL to redis://@localhost:6379/0
+redis_url = os.getenv("CACHE_REDIS_URL", None)
+if redis_url is not None:
+    config = {
+        "DEBUG": False,
+        "CACHE_TYPE": "redis",
+        "CACHE_DEFAULT_TIMEOUT": DAY,
+        "CACHE_KEY_PREFIX": "definitions",
+        "CACHE_REDIS_URL": redis_url,
+    }
+else:
+    config = {"DEBUG": True, "CACHE_TYPE": "null", "CACHE_DEFAULT_TIMEOUT": 300}
 
 cache.init_app(
     app, config=config,


### PR DESCRIPTION
Hosted redis does not allow unencrypted connections. This is a good thing, but requires a little more work. Flask-caching does not directly support using TLS, so we need to pass that information in the connection URL.
This also disables the cache locally for simplicity of testing. This can be re-enabled by passing a connection URL as an environment variable.