### PR TITLE
Production ready gunicorn config

### DIFF
--- a/language-service/Dockerfile
+++ b/language-service/Dockerfile
@@ -31,4 +31,4 @@ COPY --from=builder /venv /venv
 COPY language_service /app/
 
 EXPOSE 8000
-CMD ["gunicorn", "LanguageService:app", "--workers=4", "--worker-class=gevent", "--timeout=30", "--log-level=debug", "-b", ":8000"]
+CMD ["gunicorn", "LanguageService:app", "--config=gunicorn.conf.py"]

--- a/language-service/language_service/gunicorn.conf.py
+++ b/language-service/language_service/gunicorn.conf.py
@@ -1,10 +1,11 @@
 # Mostly necessary to keep the health check from failing when a long running call happens
+# If I revisit this then this stack overflow was pretty helpful:
+# https://pythonspeed.com/articles/gunicorn-in-docker/
 workers = 2
 threads = 4
 worker_class = "gevent"
-worker_tmp_dir = "/dev/shm"
-# If I revisit this then this stack overflow was pretty helpful:
-# https://pythonspeed.com/articles/gunicorn-in-docker/
+worker_tmp_dir = "/dev/shm"  # nosec This is low risk
+# This application is pretty well locked down in a container
 
 # We should filter the logs at the cluster level
 loglevel = "debug"

--- a/language-service/language_service/gunicorn.conf.py
+++ b/language-service/language_service/gunicorn.conf.py
@@ -1,0 +1,12 @@
+# Mostly necessary to keep the health check from failing when a long running call happens
+workers = 2
+threads = 4
+worker_class = "gevent"
+worker_tmp_dir = "/dev/shm"
+# If I revisit this then this stack overflow was pretty helpful:
+# https://pythonspeed.com/articles/gunicorn-in-docker/
+
+# We should filter the logs at the cluster level
+loglevel = "debug"
+
+bind = ":8000"


### PR DESCRIPTION
- Move configuration from command line to config file
- Set up worker concurrency to not break the health check

All the problems with the health check seem to only happen on prod, so this is partially a test. If I was going to mess with this again I might write some testing for this but hopefully it's a one time set and forget type of situation. 