### PR TITLE
Less aggressive health check

### DIFF
--- a/infrastructure/kubernetes/api/autoscale.yml
+++ b/infrastructure/kubernetes/api/autoscale.yml
@@ -1,14 +1,14 @@
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: language-service
+  name: api
 spec:
   maxReplicas: 10
   minReplicas: 2
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: language-service
+    name: api
   metrics:
   - type: Resource
     resource:

--- a/infrastructure/kubernetes/api/deployment.yml
+++ b/infrastructure/kubernetes/api/deployment.yml
@@ -41,13 +41,13 @@ spec:
             port: 4000
           initialDelaySeconds: 30
           periodSeconds: 10
-          timeoutSeconds: 3
-          failureThreshold: 1
+          timeoutSeconds: 5
+          failureThreshold: 5
         livenessProbe:
           httpGet:
             path: /health
             port: 4000
           initialDelaySeconds: 60
           periodSeconds: 10
-          timeoutSeconds: 3
-          failureThreshold: 1
+          timeoutSeconds: 5
+          failureThreshold: 5

--- a/infrastructure/kubernetes/kustomization.yaml
+++ b/infrastructure/kubernetes/kustomization.yaml
@@ -8,9 +8,11 @@ resources:
 
 - api/service.yml
 - api/deployment.yml
+- api/autoscale.yml
 
 - language-service/service.yml
 - language-service/deployment.yml
+- language-service/autoscale.yml
 
 - ingress/ingress.yml
 - certificate/cert-manager.yml

--- a/infrastructure/kubernetes/language-service/deployment.yml
+++ b/infrastructure/kubernetes/language-service/deployment.yml
@@ -34,13 +34,13 @@ spec:
             port: 8000
           initialDelaySeconds: 30
           periodSeconds: 10
-          timeoutSeconds: 3
-          failureThreshold: 1
+          timeoutSeconds: 5
+          failureThreshold: 5
         livenessProbe:
           httpGet:
             path: /health
             port: 8000
           initialDelaySeconds: 60
           periodSeconds: 10
-          timeoutSeconds: 3
-          failureThreshold: 1
+          timeoutSeconds: 5
+          failureThreshold: 5


### PR DESCRIPTION
The health check pretty much terminates a pod that has any load. Also, autoscale pods to 2 per service.