### PR TITLE
Use official elasticsearch helm

### DIFF
--- a/infrastructure/kubernetes/api/autoscale.yml
+++ b/infrastructure/kubernetes/api/autoscale.yml
@@ -4,7 +4,7 @@ metadata:
   name: api
 spec:
   maxReplicas: 10
-  minReplicas: 1
+  minReplicas: 2
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/infrastructure/kubernetes/language-service/autoscale.yml
+++ b/infrastructure/kubernetes/language-service/autoscale.yml
@@ -4,7 +4,7 @@ metadata:
   name: language-service
 spec:
   maxReplicas: 10
-  minReplicas: 1
+  minReplicas: 2
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/infrastructure/terraform/kubernetes_config/main.tf
+++ b/infrastructure/terraform/kubernetes_config/main.tf
@@ -55,36 +55,14 @@ resource "helm_release" "cert_manager" {
 
 resource "helm_release" "elasticsearch" {
   name       = "elasticsearch"
-  repository = "https://kubernetes-charts.storage.googleapis.com"
+  repository = "https://helm.elastic.co"
   chart      = "elasticsearch"
-  version    = "1.32.4"
-  timeout    = 1200
-
-  set {
-    name  = "client.replicas"
-    value = 0
-  }
-
-  set {
-    name  = "master.replicas"
-    value = 3
-  }
-
-  set {
-    name  = "data.replicas"
-    value = 0
-  }
+  version    = "7.6.1"
 }
 
 resource "helm_release" "kibana" {
   name       = "kibana"
-  repository = "https://kubernetes-charts.storage.googleapis.com"
+  repository = "https://helm.elastic.co"
   chart      = "kibana"
-  version    = "3.2.6"
-  timeout    = 1200
-
-  set {
-    name  = "image.tag"
-    value = "6.8.6"
-  }
+  version    = "7.6.1"
 }


### PR DESCRIPTION
The helm chart for stable/elasticsearch is old and seems to be having problems. While the elastic official helm chart does not officially support helm 3, it doesn't seem like there's anything that will break in the chart. Since nothing is working with the old setup, I might as well YOLO it and see if it works.