### PR TITLE
Terraform creates TLS certificate

### DIFF
--- a/infrastructure.tf
+++ b/infrastructure.tf
@@ -27,6 +27,7 @@ provider "acme" {
   server_url = "https://acme-v02.api.letsencrypt.org/directory"
 }
 
+# Held here so that Helm and K8s providers can be initialized to work on this cluster
 resource "digitalocean_kubernetes_cluster" "foreign_language_reader" {
   name    = "foreign-language-reader"
   region  = "sfo2"
@@ -46,4 +47,26 @@ module "infrastructure" {
   source           = "./infrastructure/terraform"
   cluster_name     = digitalocean_kubernetes_cluster.foreign_language_reader.name
   test_environment = var.test_environment
+}
+
+# Section to create TLS certs
+# Put at this level so we don't have to pass the DO token around
+
+resource "tls_private_key" "tls_private_key" {
+  algorithm = "RSA"
+}
+
+resource "acme_registration" "reg" {
+  account_key_pem = tls_private_key.tls_private_key.private_key_pem
+  email_address   = "letsencrypt@lucaskjaerozhang.com"
+}
+
+resource "acme_certificate" "certificate" {
+  account_key_pem = acme_registration.reg.account_key_pem
+  common_name     = "*.foreignlanguagereader.com"
+
+  dns_challenge {
+    provider      = "digitalocean"
+    DO_AUTH_TOKEN = var.digitalocean_token
+  }
 }

--- a/infrastructure.tf
+++ b/infrastructure.tf
@@ -66,7 +66,9 @@ resource "acme_certificate" "certificate" {
   common_name     = "*.foreignlanguagereader.com"
 
   dns_challenge {
-    provider      = "digitalocean"
-    DO_AUTH_TOKEN = var.digitalocean_token
+    provider = "digitalocean"
+    config = {
+      DO_AUTH_TOKEN = var.digitalocean_token
+    }
   }
 }

--- a/infrastructure.tf
+++ b/infrastructure.tf
@@ -23,6 +23,10 @@ provider "digitalocean" {
   token = var.digitalocean_token
 }
 
+provider "acme" {
+  server_url = "https://acme-staging-v02.api.letsencrypt.org/directory"
+}
+
 resource "digitalocean_kubernetes_cluster" "foreign_language_reader" {
   name    = "foreign-language-reader"
   region  = "sfo2"

--- a/infrastructure.tf
+++ b/infrastructure.tf
@@ -24,7 +24,7 @@ provider "digitalocean" {
 }
 
 provider "acme" {
-  server_url = "https://acme-staging-v02.api.letsencrypt.org/directory"
+  server_url = "https://acme-v02.api.letsencrypt.org/directory"
 }
 
 resource "digitalocean_kubernetes_cluster" "foreign_language_reader" {


### PR DESCRIPTION
There are multiple ways we generate a TLS certificate
- Amazon generates the certificate for the static content
- K8s generates the certificate for our microservices
- Elasticsearch certificate needs to be generated somehow?

It would be better to generate it in one place and give it to all the different users. Terraform is the right place for that.