### PR TITLE
Storage for definition sources

### DIFF
--- a/infrastructure/terraform/content_bucket/main.tf
+++ b/infrastructure/terraform/content_bucket/main.tf
@@ -1,0 +1,8 @@
+data "aws_caller_identity" "current" {}
+
+resource "aws_s3_bucket" "main" {
+  bucket = "foreign-language-reader-${var.name}"
+  acl    = "private"
+}
+
+# TODO give permissions for jobs to use this.

--- a/infrastructure/terraform/content_bucket/variables.tf
+++ b/infrastructure/terraform/content_bucket/variables.tf
@@ -1,0 +1,7 @@
+# variable "read_users" {
+#   description = "The IAM users to give read permissions to."
+# }
+
+variable "name" {
+  description = "The domain the site will be hosted on."
+}

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -75,6 +75,11 @@ module "storybook" {
   deploy_users = [aws_iam_user.github.name]
 }
 
+module "definitions" {
+  source = "./content_bucket"
+  name   = "definitions"
+}
+
 # Section to create TLS certs
 
 resource "tls_private_key" "tls_private_key" {


### PR DESCRIPTION
It turns out wiktionary does not like how frequently we are scraping them. A better architecture is to use their downloaded backups to parse definitions and push to ES.

This is the first step - creating an S3 bucket for parsing jobs to use.