### PR TITLE
Fix latest tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,9 @@ jobs:
         ECR_REPOSITORY: foreign-language-reader-api
         IMAGE_TAG: ${{ github.sha }}
       run: |
-        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY: .
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY
+        docker tag $ECR_REGISTRY/$ECR_REPOSITORY $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
         echo "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" > api.txt
@@ -174,7 +176,9 @@ jobs:
         ECR_REPOSITORY: foreign-language-reader-language-service
         IMAGE_TAG: ${{ github.sha }}
       run: |
-        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY: .
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY
+        docker tag $ECR_REGISTRY/$ECR_REPOSITORY $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
         echo "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" > language_service.txt

--- a/.github/workflows/k8s_test.yml
+++ b/.github/workflows/k8s_test.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     paths:
       - "infrastructure/kubernetes/**/*"
-      - "infrastructure/kubernetes/kustomization.yaml"
 
 jobs:
   build:

--- a/infrastructure/terraform/api/main.tf
+++ b/infrastructure/terraform/api/main.tf
@@ -59,7 +59,7 @@ resource "kubernetes_deployment" "api" {
         }
 
         container {
-          image = "${data.aws_caller_identity.current.account_id}.dkr.ecr.us-west-2.amazonaws.com/foreign-language-reader-api:latest"
+          image = "${data.aws_caller_identity.current.account_id}.dkr.ecr.us-west-2.amazonaws.com/foreign-language-reader-api:api:c73332bc3e4232819ffaea6cc52c5034b74b1a21"
           name  = "api"
 
           env {

--- a/infrastructure/terraform/language_service/main.tf
+++ b/infrastructure/terraform/language_service/main.tf
@@ -55,7 +55,7 @@ resource "kubernetes_deployment" "language_service" {
         }
 
         container {
-          image = "${data.aws_caller_identity.current.account_id}.dkr.ecr.us-west-2.amazonaws.com/foreign-language-reader-language-service:latest"
+          image = "${data.aws_caller_identity.current.account_id}.dkr.ecr.us-west-2.amazonaws.com/foreign-language-reader-language-service:api:c73332bc3e4232819ffaea6cc52c5034b74b1a21"
           name  = "language-service"
 
           env {


### PR DESCRIPTION
When creating the deployment in terraform, it looks for the latest tag. But it doesn't exist, so the infrastructure pass fails.
Let's tag latest for bootstrapping.