### PR TITLE
Monitor the cluster

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -81,6 +81,11 @@ module "content" {
   source = "./content"
 }
 
+# Pretty much prometheus configuration
+module "monitoring" {
+  source = "./monitoring"
+}
+
 # Ingress
 # Handles traffic going in to the cluster
 # Proxies everything through a load balancer and nginx

--- a/infrastructure/terraform/monitoring/main.tf
+++ b/infrastructure/terraform/monitoring/main.tf
@@ -1,0 +1,21 @@
+resource "kubernetes_namespace" "monitoring" {
+  metadata {
+    annotations = {
+      name = "monitoring"
+    }
+
+    name = "monitoring"
+  }
+}
+
+resource "helm_release" "prometheus" {
+  name       = "prometheus"
+  repository = "https://kubernetes-charts.storage.googleapis.com"
+  chart      = "prometheus-operator"
+  version    = "0.37.0"
+  namespace  = "monitoring"
+
+  depends_on = [
+    kubernetes_namespace.monitoring
+  ]
+}


### PR DESCRIPTION
These monitoring configs are simple to start. Uses a default prometheus config to keep track of cluster metrics.