### PR TITLE
Create metrics server for autoscaling services

### DIFF
--- a/infrastructure.tf
+++ b/infrastructure.tf
@@ -39,7 +39,7 @@ resource "digitalocean_kubernetes_cluster" "foreign_language_reader" {
     size       = "s-2vcpu-4gb"
     auto_scale = true
     min_nodes  = 1
-    max_nodes  = 5
+    max_nodes  = 6
   }
 }
 

--- a/infrastructure/terraform/api/main.tf
+++ b/infrastructure/terraform/api/main.tf
@@ -186,6 +186,7 @@ resource "kubernetes_deployment" "api" {
   lifecycle {
     ignore_changes = [
       spec.0.template.0.spec.0.container.0.image,
+      spec.0.replicas
     ]
   }
 

--- a/infrastructure/terraform/language_service/main.tf
+++ b/infrastructure/terraform/language_service/main.tf
@@ -140,6 +140,7 @@ resource "kubernetes_deployment" "language_service" {
   lifecycle {
     ignore_changes = [
       spec.0.template.0.spec.0.container.0.image,
+      spec.0.replicas
     ]
   }
 }

--- a/infrastructure/terraform/monitoring/main.tf
+++ b/infrastructure/terraform/monitoring/main.tf
@@ -7,3 +7,11 @@ resource "kubernetes_namespace" "monitoring" {
     name = "monitoring"
   }
 }
+
+# Required for horizontal pod autoscaling to work
+resource "helm_release" "metrics_server" {
+  name       = "metrics-server"
+  repository = "https://kubernetes-charts.storage.googleapis.com"
+  chart      = "metrics-server"
+  version    = "2.10.1"
+}


### PR DESCRIPTION
Autoscaling cannot happen if we don't have metrics on pods. This is a Kubernetes extension to collect those metrics.