### PR TITLE
Normalize Chinese to traditional

### DIFF
--- a/api-v2/app/com/foreignlanguagereader/api/domain/Language.scala
+++ b/api-v2/app/com/foreignlanguagereader/api/domain/Language.scala
@@ -13,8 +13,13 @@ object Language extends Enumeration {
     Language.values.find(_.toString == s)
 
   implicit val languageFormat: Format[Language] = new Format[Language] {
-    def reads(json: JsValue) = JsSuccess(Language.withName(json.as[String]))
-    def writes(language: Language.Language) = JsString(language.toString)
+    def reads(json: JsValue): JsResult[Language] =
+      fromString(json.toString) match {
+        case Some(language) => JsSuccess(language)
+        case None           => JsError("Invalid language")
+      }
+    def writes(language: Language.Language): JsString =
+      JsString(language.toString)
   }
 
   implicit def pathBinder: PathBindable[Language] =

--- a/api-v2/app/com/foreignlanguagereader/api/domain/definition/entry/DefinitionEntry.scala
+++ b/api-v2/app/com/foreignlanguagereader/api/domain/definition/entry/DefinitionEntry.scala
@@ -24,14 +24,19 @@ object DefinitionEntry {
     new Format[DefinitionEntry] {
       override def reads(json: JsValue): JsResult[DefinitionEntry] = {
         json \ "source" match {
-          case JsDefined(JsString(source))
-              if source.equals(DefinitionSource.CEDICT.toString) =>
-            CEDICTDefinitionEntry.format.reads(json)
-          case JsDefined(JsString(source))
-              if source.equals(DefinitionSource.WIKTIONARY.toString) =>
-            WiktionaryDefinitionEntry.format.reads(json)
+          case JsDefined(JsString(source)) =>
+            DefinitionSource.fromString(source) match {
+              case Some(DefinitionSource.CEDICT) =>
+                CEDICTDefinitionEntry.format.reads(json)
+              case Some(DefinitionSource.WIKTIONARY) =>
+                WiktionaryDefinitionEntry.format.reads(json)
+              case _ =>
+                JsError("Unknown definition source")
+            }
           case _ =>
-            JsError("Unknown definition source")
+            JsError(
+              "Definition source was not defined, cannot decide how to handle"
+            )
         }
       }
       override def writes(o: DefinitionEntry): JsValue = o match {

--- a/api-v2/app/com/foreignlanguagereader/api/domain/definition/entry/DefinitionSource.scala
+++ b/api-v2/app/com/foreignlanguagereader/api/domain/definition/entry/DefinitionSource.scala
@@ -13,6 +13,9 @@ object DefinitionSource extends Enumeration {
   val WIKTIONARY: Value = Value("WIKTIONARY")
   val MULTIPLE: Value = Value("MULTIPLE")
 
+  def fromString(source: String): Option[DefinitionSource] =
+    DefinitionSource.values.find(_.toString == source)
+
   // Makes sure we can serialize and deserialize this to JSON
   implicit val sourceFormat: Format[DefinitionSource] =
     new Format[DefinitionSource] {

--- a/api-v2/app/com/foreignlanguagereader/api/domain/definition/entry/DefinitionSource.scala
+++ b/api-v2/app/com/foreignlanguagereader/api/domain/definition/entry/DefinitionSource.scala
@@ -1,6 +1,13 @@
 package com.foreignlanguagereader.api.domain.definition.entry
 
-import play.api.libs.json.{Format, JsString, JsSuccess, JsValue}
+import play.api.libs.json.{
+  Format,
+  JsError,
+  JsResult,
+  JsString,
+  JsSuccess,
+  JsValue
+}
 
 /*
  * An enum that defines where a definition came from
@@ -19,8 +26,11 @@ object DefinitionSource extends Enumeration {
   // Makes sure we can serialize and deserialize this to JSON
   implicit val sourceFormat: Format[DefinitionSource] =
     new Format[DefinitionSource] {
-      def reads(json: JsValue) =
-        JsSuccess(DefinitionSource.withName(json.as[String]))
+      def reads(json: JsValue): JsResult[DefinitionSource] =
+        fromString(json.as[String]) match {
+          case Some(source) => JsSuccess(source)
+          case None         => JsError("Unknown definition source")
+        }
       def writes(source: DefinitionSource.DefinitionSource) =
         JsString(source.toString)
     }

--- a/api-v2/app/com/foreignlanguagereader/api/dto/v1/definition/DefinitionDTO.scala
+++ b/api-v2/app/com/foreignlanguagereader/api/dto/v1/definition/DefinitionDTO.scala
@@ -20,6 +20,8 @@ object DefinitionDTO {
     }
 
   // Default to generic
-  def apply(subdefinitions: List[String], tag: String, examples: List[String]) =
+  def apply(subdefinitions: List[String],
+            tag: String,
+            examples: List[String]): DefinitionDTO =
     GenericDefinitionDTO(subdefinitions, tag, examples)
 }

--- a/api-v2/app/com/foreignlanguagereader/api/dto/v1/health/Readiness.scala
+++ b/api-v2/app/com/foreignlanguagereader/api/dto/v1/health/Readiness.scala
@@ -11,13 +11,13 @@ import play.api.libs.json._
 case class Readiness(database: ReadinessStatus,
                      content: ReadinessStatus,
                      languageService: ReadinessStatus) {
-  def overall: ReadinessStatus = {
-    val statuses = List(database, content, languageService)
-    if (statuses.forall(_.eq(ReadinessStatus.UP))) ReadinessStatus.UP
-    else if (statuses.forall(_.eq(ReadinessStatus.DOWN)))
-      ReadinessStatus.DOWN
-    else ReadinessStatus.DEGRADED
-  }
+  def overall: ReadinessStatus =
+    List(database, content, languageService) match {
+      case up if up.forall(_.eq(ReadinessStatus.UP)) => ReadinessStatus.UP
+      case down if down.forall(_.eq(ReadinessStatus.DOWN)) =>
+        ReadinessStatus.DOWN
+      case _ => ReadinessStatus.DEGRADED
+    }
 }
 
 object Readiness {
@@ -32,7 +32,7 @@ object ReadinessStatus extends Enumeration {
   implicit val readinessStatusFormat: Format[ReadinessStatus] =
     new Format[ReadinessStatus] {
       def reads(json: JsValue) =
-        JsSuccess(ReadinessStatus.withName(json.as[String]))
+        JsError("We don't read these")
       def writes(status: ReadinessStatus.ReadinessStatus) =
         JsString(status.toString)
     }

--- a/api-v2/app/com/foreignlanguagereader/api/service/definition/Cedict.scala
+++ b/api-v2/app/com/foreignlanguagereader/api/service/definition/Cedict.scala
@@ -1,0 +1,78 @@
+package com.foreignlanguagereader.api.service.definition
+
+import com.foreignlanguagereader.api.domain.definition.entry.CEDICTDefinitionEntry
+import play.api.Logger
+
+import scala.io.{BufferedSource, Source}
+import scala.util.{Failure, Success, Using}
+
+object Cedict {
+  val logger: Logger = Logger(this.getClass)
+
+  private[this] val CEDICTPath = "/resources/definition/chinese/cedict_ts.u8"
+
+  val definitions: Map[String, CEDICTDefinitionEntry] =
+    Using(
+      Source.fromInputStream(
+        this.getClass
+          .getResourceAsStream(CEDICTPath)
+      )
+    ) { cedict =>
+      parseCedictFile(cedict).map(entry => entry.traditional -> entry).toMap
+    } match {
+      case Success(d) =>
+        logger.info("Successfully loaded CEDICT")
+        d
+      case Failure(e) =>
+        throw new IllegalStateException("Failed to load CEDICT", e)
+    }
+
+  private[this] val simplifiedToTraditionalMapping: Map[String, String] =
+    definitions.values.map(entry => entry.simplified -> entry.traditional).toMap
+  private[this] val simplified: Set[String] =
+    definitions.values.map(_.simplified).toSet
+  private[this] val traditional: Set[String] =
+    definitions.values.map(_.traditional).toSet
+
+  /**
+    * Converts a given token into traditional Chinese
+    * @param token The token to normalize
+    * @return The token as traditional
+    */
+  def convertToTraditional(token: String): String = token match {
+    case t if traditional.contains(t) =>
+      logger.info(
+        s"Token $token was already traditional, no normalization needed."
+      )
+      t
+    case s if simplified.contains(s) =>
+      val t = simplifiedToTraditionalMapping.getOrElse(s, token)
+      logger.info(
+        s"Token $token normalized from simplified $s to traditional $t."
+      )
+      t
+    case _ =>
+      logger.warn(s"Unknown token $token, unable to normalize.")
+      token
+  }
+
+  private[this] def parseCedictFile(
+    cedict: BufferedSource
+  ): List[CEDICTDefinitionEntry] =
+    cedict
+      .getLines()
+      // These lines are all dictionary comments. License, schema, etc.
+      .filterNot(_.startsWith("#"))
+      .map(line => {
+        val s"$traditional $simplified [$pinyin] /$definition/" = line
+        val subdefinitions = definition.split("/").toList
+        CEDICTDefinitionEntry(
+          subdefinitions,
+          pinyin,
+          simplified,
+          traditional,
+          traditional
+        )
+      })
+      .toList
+}

--- a/api-v2/app/com/foreignlanguagereader/api/service/definition/Cedict.scala
+++ b/api-v2/app/com/foreignlanguagereader/api/service/definition/Cedict.scala
@@ -27,6 +27,9 @@ object Cedict {
         throw new IllegalStateException("Failed to load CEDICT", e)
     }
 
+  def getDefinition(token: String): Option[CEDICTDefinitionEntry] =
+    definitions.get(token)
+
   private[this] val simplifiedToTraditionalMapping: Map[String, String] =
     definitions.values.map(entry => entry.simplified -> entry.traditional).toMap
   private[this] val simplified: Set[String] =

--- a/api-v2/app/com/foreignlanguagereader/api/service/definition/ChineseDefinitionService.scala
+++ b/api-v2/app/com/foreignlanguagereader/api/service/definition/ChineseDefinitionService.scala
@@ -92,13 +92,13 @@ class ChineseDefinitionService @Inject()(
       Option[List[WiktionaryDefinitionEntry]]) = {
     val (cedict, wiktionary) = definitions.foldLeft(
       (List[CEDICTDefinitionEntry](), List[WiktionaryDefinitionEntry]())
-    )(
-      (acc, entry) =>
-        entry match {
-          case c: CEDICTDefinitionEntry     => (c :: acc._1, acc._2)
-          case w: WiktionaryDefinitionEntry => (acc._1, w :: acc._2)
+    )((acc, entry) => {
+      val (cedict, wiktionary) = acc
+      entry match {
+        case c: CEDICTDefinitionEntry     => (c :: cedict, wiktionary)
+        case w: WiktionaryDefinitionEntry => (cedict, w :: wiktionary)
       }
-    )
+    })
     (
       if (cedict.nonEmpty) Some(cedict) else None,
       if (wiktionary.nonEmpty) Some(wiktionary) else None

--- a/api-v2/app/com/foreignlanguagereader/api/service/definition/ChineseDefinitionService.scala
+++ b/api-v2/app/com/foreignlanguagereader/api/service/definition/ChineseDefinitionService.scala
@@ -47,6 +47,12 @@ class ChineseDefinitionService @Inject()(
     DefinitionSource.WIKTIONARY
   )
 
+  // Convert everything to traditional
+  // We need one lookup token for elasticsearch.
+  // And traditional is more specific
+  override def preprocessTokenForRequest(token: String): String =
+    Cedict.convertToTraditional(token)
+
   override def enrichDefinitions(
     definitionLanguage: Language,
     word: String,

--- a/api-v2/app/com/foreignlanguagereader/api/service/definition/ChineseDefinitionService.scala
+++ b/api-v2/app/com/foreignlanguagereader/api/service/definition/ChineseDefinitionService.scala
@@ -26,7 +26,7 @@ import javax.inject.Inject
 import play.api.Logger
 import play.api.libs.json.{Json, Reads}
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * Language specific handling for Chinese.
@@ -45,6 +45,22 @@ class ChineseDefinitionService @Inject()(
     Set(DefinitionSource.CEDICT, DefinitionSource.WIKTIONARY)
   override val webSources: Set[DefinitionSource] = Set(
     DefinitionSource.WIKTIONARY
+  )
+
+  def cedictFetcher
+    : (Language, String) => Future[Option[Seq[DefinitionEntry]]] =
+    (_, word: String) =>
+      Cedict.getDefinition(word) match {
+        case Some(entry) => Future.successful(Some(List(entry)))
+        case None        => Future.successful(None)
+    }
+
+  override val definitionFetchers
+    : Map[(DefinitionSource, Language), (Language, String) => Future[
+      Option[Seq[DefinitionEntry]]
+    ]] = Map(
+    (DefinitionSource.CEDICT, Language.ENGLISH) -> cedictFetcher,
+    (DefinitionSource.WIKTIONARY, Language.ENGLISH) -> languageServiceFetcher
   )
 
   // Convert everything to traditional

--- a/api-v2/test/com/foreignlanguagereader/api/service/definition/CedictTest.scala
+++ b/api-v2/test/com/foreignlanguagereader/api/service/definition/CedictTest.scala
@@ -20,4 +20,16 @@ class CedictTest extends AnyFunSpec {
       assert(Cedict.convertToTraditional("ABCD") == "ABCD")
     }
   }
+
+  it("can get definitions") {
+    val library = Cedict.getDefinition("圖書館")
+    assert(library.isDefined)
+    val libraryDefinition = library.get
+    assert(libraryDefinition.pinyin == "tu2 shu1 guan3")
+    assert(libraryDefinition.traditional == "圖書館")
+    assert(libraryDefinition.simplified == "图书馆")
+    assert(libraryDefinition.subdefinitions.size == 2)
+    assert(libraryDefinition.subdefinitions(0) == "library")
+    assert(libraryDefinition.subdefinitions(1) == "CL:家[jia1],個|个[ge4]")
+  }
 }

--- a/api-v2/test/com/foreignlanguagereader/api/service/definition/CedictTest.scala
+++ b/api-v2/test/com/foreignlanguagereader/api/service/definition/CedictTest.scala
@@ -1,0 +1,23 @@
+package com.foreignlanguagereader.api.service.definition
+
+import org.scalatest.funspec.AnyFunSpec
+
+class CedictTest extends AnyFunSpec {
+  it("can parse CEDICT") {
+    val cedict = Cedict.definitions
+  }
+
+  describe("can convert characters to traditional characters") {
+    it("does nothing when they are already traditional") {
+      assert(Cedict.convertToTraditional("圖書館") == "圖書館")
+    }
+
+    it("can convert from simplified") {
+      assert(Cedict.convertToTraditional("图书馆") == "圖書館")
+    }
+
+    it("does nothing if the word isn't found") {
+      assert(Cedict.convertToTraditional("ABCD") == "ABCD")
+    }
+  }
+}


### PR DESCRIPTION
Chinese words can be written in simplified or traditional. We need to index them under one, so we can pull from all available sources. Traditional is better than simplified, because it is more specific. Every traditional character maps to only one simplified character, but one simplified character can map to multiple traditional.