### PR TITLE
Definitions need a unique ID

### DIFF
--- a/api-v2/app/com/foreignlanguagereader/api/domain/definition/ChineseDefinition.scala
+++ b/api-v2/app/com/foreignlanguagereader/api/domain/definition/ChineseDefinition.scala
@@ -35,6 +35,7 @@ case class ChineseDefinition(override val subdefinitions: List[String],
   val pronunciation: ChinesePronunciation =
     ChineseDefinitionService.getPronunciation(inputPinyin)
   val ipa: String = pronunciation.ipa
+  val id: String = generateId()
 
   val (simplified: Option[String], traditional: Option[Seq[String]]) =
     (inputSimplified, inputTraditional) match {
@@ -54,13 +55,14 @@ case class ChineseDefinition(override val subdefinitions: List[String],
 
   lazy val toDTO: ChineseDefinitionDTO =
     ChineseDefinitionDTO(
-      subdefinitions,
-      tag,
-      examples,
-      simplified,
-      traditional,
-      pronunciation,
-      hsk
+      id = id,
+      subdefinitions = subdefinitions,
+      tag = tag,
+      examples = examples,
+      simplified = simplified,
+      traditional = traditional,
+      pronunciation = pronunciation,
+      hsk = hsk
     )
 }
 object ChineseDefinition {

--- a/api-v2/app/com/foreignlanguagereader/api/domain/definition/Definition.scala
+++ b/api-v2/app/com/foreignlanguagereader/api/domain/definition/Definition.scala
@@ -22,6 +22,17 @@ trait Definition {
   val source: DefinitionSource
   val token: String
 
+  // We need a way to uniquely identify parts of speech
+  // Some level of collisions are unavoidable but they should be as rare as possible.
+  val id: String
+  def generateId(): String = {
+    val partOfSpeech = tag match {
+      case Some(t) => t
+      case None    => "UNKNOWN"
+    }
+    s"$wordLanguage:$token:$ipa:$partOfSpeech"
+  }
+
   // This always needs to know how to convert itself to a DTO
   val toDTO: DefinitionDTO
 }

--- a/api-v2/app/com/foreignlanguagereader/api/domain/definition/GenericDefinition.scala
+++ b/api-v2/app/com/foreignlanguagereader/api/domain/definition/GenericDefinition.scala
@@ -20,8 +20,15 @@ case class GenericDefinition(subdefinitions: List[String],
                              source: DefinitionSource,
                              token: String)
     extends Definition {
+  val id: String = generateId()
+
   override lazy val toDTO: DefinitionDTO =
-    GenericDefinitionDTO(subdefinitions, tag, examples)
+    GenericDefinitionDTO(
+      id = id,
+      subdefinitions = subdefinitions,
+      tag = tag,
+      examples = examples
+    )
 }
 object GenericDefinition {
   implicit val format: Format[GenericDefinition] =

--- a/api-v2/app/com/foreignlanguagereader/api/dto/v1/definition/ChineseDefinitionDTO.scala
+++ b/api-v2/app/com/foreignlanguagereader/api/dto/v1/definition/ChineseDefinitionDTO.scala
@@ -7,7 +7,8 @@ import play.api.libs.json.{Format, Json}
 import sangria.macros.derive.{ObjectTypeDescription, deriveObjectType}
 import sangria.schema.ObjectType
 
-case class ChineseDefinitionDTO(subdefinitions: List[String],
+case class ChineseDefinitionDTO(id: String,
+                                subdefinitions: List[String],
                                 tag: Option[PartOfSpeech],
                                 examples: Option[List[String]],
                                 simplified: Option[String],

--- a/api-v2/app/com/foreignlanguagereader/api/dto/v1/definition/DefinitionDTO.scala
+++ b/api-v2/app/com/foreignlanguagereader/api/dto/v1/definition/DefinitionDTO.scala
@@ -5,6 +5,7 @@ import play.api.libs.json.{Format, JsError, JsResult, JsValue}
 import sangria.schema.UnionType
 
 trait DefinitionDTO {
+  val id: String
   val subdefinitions: List[String]
   val tag: Option[PartOfSpeech]
   val examples: Option[List[String]]
@@ -30,8 +31,14 @@ object DefinitionDTO {
   )
 
   // Constructor that defaults to generic
-  def apply(subdefinitions: List[String],
+  def apply(id: String,
+            subdefinitions: List[String],
             tag: Option[PartOfSpeech],
             examples: Option[List[String]]): DefinitionDTO =
-    GenericDefinitionDTO(subdefinitions, tag, examples)
+    GenericDefinitionDTO(
+      id = id,
+      subdefinitions = subdefinitions,
+      tag = tag,
+      examples = examples
+    )
 }

--- a/api-v2/app/com/foreignlanguagereader/api/dto/v1/definition/GenericDefinitionDTO.scala
+++ b/api-v2/app/com/foreignlanguagereader/api/dto/v1/definition/GenericDefinitionDTO.scala
@@ -5,7 +5,8 @@ import play.api.libs.json.{Format, Json}
 import sangria.macros.derive.{ObjectTypeDescription, deriveObjectType}
 import sangria.schema.ObjectType
 
-case class GenericDefinitionDTO(subdefinitions: List[String],
+case class GenericDefinitionDTO(id: String,
+                                subdefinitions: List[String],
                                 tag: Option[PartOfSpeech],
                                 examples: Option[List[String]])
     extends DefinitionDTO

--- a/api-v2/test/com/foreignlanguagereader/api/domain/definition/ChineseDefinitionTest.scala
+++ b/api-v2/test/com/foreignlanguagereader/api/domain/definition/ChineseDefinitionTest.scala
@@ -19,6 +19,10 @@ class ChineseDefinitionTest extends AnyFunSpec {
   )
 
   describe("A Chinese definition") {
+    it("can properly generate an id") {
+      assert(example.id == "CHINESE:你好:[ni] [xɑʊ̯]:Noun")
+    }
+
     describe("when getting pronunciation") {
       it("can determine pronunciation from pinyin") {
         assert(example.pronunciation.pinyin == "ni hao")
@@ -85,6 +89,7 @@ class ChineseDefinitionTest extends AnyFunSpec {
 
     it("can convert itself to a DTO") {
       val compareAgainst = ChineseDefinitionDTO(
+        example.id,
         example.subdefinitions,
         example.tag,
         example.examples,


### PR DESCRIPTION
First attempt at a unique ID for persistence. Word ids are a combination of language, spelling, part of speech, and pronunciation.

Pros:
- Protects against homographs (eg: lead in "lead on" vs. "lead paint").
- Function commonly shifts the meaning.

Cons:
- Still some collisions.
- Not all definition sources have part of speech.