### PR TITLE
Fix master codecov

### DIFF
--- a/.github/workflows/master_codecov.yml
+++ b/.github/workflows/master_codecov.yml
@@ -11,10 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 14
       uses: actions/setup-java@v1
       with:
         java-version: '14.0.1'
+    - name: Compile
+      run: sbt compile
     - name: Run tests
       run: sbt coverage test
     - name: Enforce coverage

--- a/.github/workflows/master_codecov.yml
+++ b/.github/workflows/master_codecov.yml
@@ -7,16 +7,14 @@ on:
 
 jobs:
   api:
-    name: API V2 code coverage
+    name: Scala code coverage
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Move build files to root of build worker
-      run: mv api-v2/* .
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: '11.0.3'
+        java-version: '14.0.1'
     - name: Run tests
       run: sbt coverage test
     - name: Enforce coverage
@@ -24,24 +22,4 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:
-        flags: unittest,api
-
-  definitions:
-    name: Definitions code coverage
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - name: Move build files to root of build worker
-      run: mv content/definitions/* .
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
-      with:
-        java-version: '11.0.3'
-    - name: Run tests
-      run: sbt coverage test
-    - name: Generate coverage
-      run: sbt coverageReport
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
-      with:
-        flags: unittest,definitions
+        flags: unittest


### PR DESCRIPTION
The master baseline coverage script is not updated to use the new build process. This fixes that.