### PR TITLE
Codecov works for scala 2.11

### DIFF
--- a/.github/workflows/master_codecov.yml
+++ b/.github/workflows/master_codecov.yml
@@ -29,4 +29,4 @@ jobs:
       uses: codacy/codacy-coverage-reporter-action@master
       with:
         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-        coverage-reports: api/target/scala-2.12/coverage-report/cobertura.xml, content/target/scala-2.12/coverage-report/cobertura.xml, domain/target/scala-2.12/coverage-report/cobertura.xml, jobs/target/scala-2.12/coverage-report/cobertura.xml
+        coverage-reports: api/target/scala-2.11/coverage-report/cobertura.xml, content/target/scala-2.11/coverage-report/cobertura.xml, domain/target/scala-2.11/coverage-report/cobertura.xml, jobs/target/scala-2.11/coverage-report/cobertura.xml

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ logs
 project/project
 project/target
 target
+.bsp/sbt.json


### PR DESCRIPTION
The merge to master automation wasn't updated for this version of scala.