### PR TITLE
Use official elasticsearch client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,12 +91,13 @@ lazy val playDependencies = Seq(
   dependencies.mockito
 )
 
+lazy val excludeJacksonRule =
+  ExclusionRule(organization = "com.fasterxml.jackson")
+
 lazy val dependencies =
   new {
     val scalatestVersion = "3.2.2"
     val sparkVersion = "2.4.4"
-    val sparkXmlVersion = "0.10.0"
-    val elastic4sVersion = "7.1.0"
 
     val scalactic = "org.scalactic" %% "scalactic" % scalatestVersion
     val scalatest = "org.scalatest" %% "scalatest" % scalatestVersion
@@ -110,7 +111,7 @@ lazy val dependencies =
     val sparkSql = "org.apache.spark" %% "spark-sql" % sparkVersion
     val sparkMl =
       "org.apache.spark" %% "spark-mllib" % sparkVersion
-    val sparkXml = "com.databricks" %% "spark-xml" % sparkXmlVersion
+    val sparkXml = "com.databricks" %% "spark-xml" % "0.10.0"
     val sparkNLP =
       "com.johnsnowlabs.nlp" %% "spark-nlp" % "2.6.3"
 
@@ -123,7 +124,7 @@ lazy val dependencies =
       "commons-io" % "commons-io" % "2.4" // required for org.apache.commons.io.Charsets that is used internally
 
     val elasticsearchHighLevelClient =
-      "org.elasticsearch.client" % "elasticsearch-rest-high-level-client" % "7.9.3"
+      "org.elasticsearch.client" % "elasticsearch-rest-high-level-client" % "7.9.3" excludeAll (excludeJacksonRule)
 
     val sangria = "org.sangria-graphql" %% "sangria" % "2.0.0"
     val sangriaPlay = "org.sangria-graphql" %% "sangria-play-json" % "2.0.0"

--- a/build.sbt
+++ b/build.sbt
@@ -24,9 +24,6 @@ lazy val content = project
     settings,
     assemblySettings,
     libraryDependencies ++= commonDependencies ++ Seq(
-      // Used to generate elasticsearch matchers
-      dependencies.elastic4s,
-      dependencies.elastic4sPlay,
       dependencies.scalatestPlay,
       dependencies.opencc4j
     )
@@ -41,9 +38,6 @@ lazy val domain = project
       // Dependency injection
       guice,
       // Used to generate elasticsearch matchers
-      dependencies.elastic4s,
-      dependencies.elastic4sTestkit,
-      dependencies.elastic4sPlay,
       dependencies.elasticsearchHighLevelClient,
       // Testing
       dependencies.mockito,
@@ -128,16 +122,10 @@ lazy val dependencies =
     val apacheCommonsIo =
       "commons-io" % "commons-io" % "2.4" // required for org.apache.commons.io.Charsets that is used internally
 
-    val elastic4s =
-      "com.sksamuel.elastic4s" %% "elastic4s-client-esjava" % elastic4sVersion
-    val elastic4sTestkit =
-      "com.sksamuel.elastic4s" %% "elastic4s-testkit" % elastic4sVersion % "test"
     val elasticsearchHighLevelClient =
       "org.elasticsearch.client" % "elasticsearch-rest-high-level-client" % "7.9.3"
 
     val sangria = "org.sangria-graphql" %% "sangria" % "2.0.0"
-    val elastic4sPlay =
-      "com.sksamuel.elastic4s" %% "elastic4s-json-play" % elastic4sVersion
     val sangriaPlay = "org.sangria-graphql" %% "sangria-play-json" % "2.0.0"
 
     val googleCloudClient =

--- a/build.sbt
+++ b/build.sbt
@@ -44,6 +44,7 @@ lazy val domain = project
       dependencies.elastic4s,
       dependencies.elastic4sTestkit,
       dependencies.elastic4sPlay,
+      dependencies.elasticsearchHighLevelClient,
       // Testing
       dependencies.mockito,
       dependencies.scalatestPlay,
@@ -131,6 +132,8 @@ lazy val dependencies =
       "com.sksamuel.elastic4s" %% "elastic4s-client-esjava" % elastic4sVersion
     val elastic4sTestkit =
       "com.sksamuel.elastic4s" %% "elastic4s-testkit" % elastic4sVersion % "test"
+    val elasticsearchHighLevelClient =
+      "org.elasticsearch.client" % "elasticsearch-rest-high-level-client" % "7.9.3"
 
     val sangria = "org.sangria-graphql" %% "sangria" % "2.0.0"
     val elastic4sPlay =

--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,12 @@ lazy val domain = project
       dependencies.hadoopCommon,
       dependencies.apacheCommonsIo
     ),
-    dependencyOverrides += dependencies.hadoopClient
+    dependencyOverrides ++= Seq(
+      dependencies.hadoopClient,
+      "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.6.7.1",
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.7",
+      "com.fasterxml.jackson.core" % "jackson-core" % "2.6.7"
+    )
   )
   .dependsOn(content)
 
@@ -92,7 +97,7 @@ lazy val playDependencies = Seq(
 )
 
 lazy val excludeJacksonRule =
-  ExclusionRule(organization = "com.fasterxml.jackson")
+  ExclusionRule(organization = "com.fasterxml.jackson.core")
 
 lazy val dependencies =
   new {
@@ -124,7 +129,7 @@ lazy val dependencies =
       "commons-io" % "commons-io" % "2.4" // required for org.apache.commons.io.Charsets that is used internally
 
     val elasticsearchHighLevelClient =
-      "org.elasticsearch.client" % "elasticsearch-rest-high-level-client" % "7.9.3" excludeAll (excludeJacksonRule)
+      "org.elasticsearch.client" % "elasticsearch-rest-high-level-client" % "7.9.3"
 
     val sangria = "org.sangria-graphql" %% "sangria" % "2.0.0"
     val sangriaPlay = "org.sangria-graphql" %% "sangria-play-json" % "2.0.0"

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,8 @@ lazy val api = project
   .settings(
     settings,
     assemblySettings,
-    libraryDependencies ++= commonDependencies ++ playDependencies
+    libraryDependencies ++= commonDependencies ++ playDependencies,
+    dependencyOverrides ++= forcedDependencies
   )
   .dependsOn(domain)
 
@@ -54,12 +55,7 @@ lazy val domain = project
       dependencies.hadoopCommon,
       dependencies.apacheCommonsIo
     ),
-    dependencyOverrides ++= Seq(
-      dependencies.hadoopClient,
-      "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.6.7.1",
-      "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.7",
-      "com.fasterxml.jackson.core" % "jackson-core" % "2.6.7"
-    )
+    dependencyOverrides ++= forcedDependencies
   )
   .dependsOn(content)
 
@@ -77,7 +73,8 @@ lazy val jobs = project
       dependencies.sparkCore % "provided",
       dependencies.sparkSql % "provided",
       dependencies.sparkXml
-    )
+    ),
+    dependencyOverrides ++= forcedDependencies
   )
   .dependsOn(content)
 
@@ -96,8 +93,14 @@ lazy val playDependencies = Seq(
   dependencies.mockito
 )
 
-lazy val excludeJacksonRule =
-  ExclusionRule(organization = "com.fasterxml.jackson.core")
+// Pretty much everything in here is because Spark NLP has versions that conflicts with other dependencies.
+lazy val forcedDependencies = Seq(
+  dependencies.hadoopClient,
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.6.7.1",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.7",
+  "com.fasterxml.jackson.core" % "jackson-core" % "2.6.7",
+  "org.projectlombok" % "lombok" % "1.18.16"
+)
 
 lazy val dependencies =
   new {

--- a/content/src/main/scala/com/foreignlanguagereader/content/types/internal/definition/Definition.scala
+++ b/content/src/main/scala/com/foreignlanguagereader/content/types/internal/definition/Definition.scala
@@ -7,8 +7,6 @@ import com.foreignlanguagereader.content.types.internal.definition.DefinitionSou
 import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech.PartOfSpeech
 import com.foreignlanguagereader.content.util.JsonSequenceHelper
 import com.foreignlanguagereader.dto.v1.definition.DefinitionDTO
-import com.sksamuel.elastic4s.playjson._
-import com.sksamuel.elastic4s.{HitReader, Indexable}
 import play.api.libs.json._
 
 trait Definition {
@@ -75,8 +73,4 @@ object Definition {
     }
   implicit val helper: JsonSequenceHelper[Definition] =
     new JsonSequenceHelper[Definition]
-
-  // Elasticsearch
-  implicit val hitReader: HitReader[Definition] = playJsonHitReader[Definition]
-  implicit val indexable: Indexable[Definition] = playJsonIndexable[Definition]
 }

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/common/Circuitbreaker.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/common/Circuitbreaker.scala
@@ -47,6 +47,11 @@ trait Circuitbreaker {
       case breaker if breaker.isOpen     => ReadinessStatus.DOWN
     }
 
+  def withBreakerCurried[T](logIfError: String)(
+      body: => Future[T]
+  ): Nested[Future, CircuitBreakerResult, T] =
+    withBreaker(logIfError, defaultIsFailure, defaultIsSuccess[T], body)
+
   def withBreaker[T](
       logIfError: String,
       body: => Future[T]

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/common/Circuitbreaker.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/common/Circuitbreaker.scala
@@ -47,21 +47,16 @@ trait Circuitbreaker {
       case breaker if breaker.isOpen     => ReadinessStatus.DOWN
     }
 
-  def withBreakerCurried[T](logIfError: String)(
+  def withBreaker[T](logIfError: String)(
       body: => Future[T]
   ): Nested[Future, CircuitBreakerResult, T] =
-    withBreaker(logIfError, defaultIsFailure, defaultIsSuccess[T], body)
-
-  def withBreaker[T](
-      logIfError: String,
-      body: => Future[T]
-  ): Nested[Future, CircuitBreakerResult, T] =
-    withBreaker(logIfError, defaultIsFailure, defaultIsSuccess[T], body)
+    withBreaker(logIfError, defaultIsFailure, defaultIsSuccess[T])(body)
 
   def withBreaker[T](
       logIfError: String,
       isFailure: Throwable => Boolean,
-      isSuccess: T => Boolean,
+      isSuccess: T => Boolean
+  )(
       body: => Future[T]
   ): Nested[Future, CircuitBreakerResult, T] =
     Nested[Future, CircuitBreakerResult, T](

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/common/WsClient.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/common/WsClient.scala
@@ -27,7 +27,8 @@ trait WsClient extends Circuitbreaker {
     withBreaker(
       s"Failed to get $typeName from $url",
       isFailure,
-      defaultIsSuccess[T],
+      defaultIsSuccess[T]
+    )(
       ws.url(url)
         // Doubled so that the circuit breaker will handle it.
         .withRequestTimeout(timeout * 2)

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchClient.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchClient.scala
@@ -14,7 +14,7 @@ import org.elasticsearch.action.bulk.BulkRequest
 import org.elasticsearch.action.index.IndexRequest
 import org.elasticsearch.action.search.{MultiSearchRequest, SearchRequest}
 import org.elasticsearch.action.{ActionRequest, ActionResponse}
-import play.api.libs.json.{Reads, Writes}
+import play.api.libs.json._
 import play.api.{Configuration, Logger}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -48,6 +48,9 @@ class ElasticsearchClient @Inject() (
       reads: Reads[T],
       writes: Writes[T]
   ): Future[List[List[T]]] = {
+    implicit val reader: ElasticsearchResponseReader =
+      new ElasticsearchResponseReader()
+
     // Fork and join for getting each request
     requests
       .traverse(request =>

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchClient.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchClient.scala
@@ -52,7 +52,7 @@ class ElasticsearchClient @Inject() (
     // Fork and join for getting each request
     requests
       .traverse(request =>
-        withBreakerCurried(
+        withBreaker(
           s"Error executing elasticearch query: $request due to error"
         )(client.multisearch(request.query)).value
           .map(result =>
@@ -146,7 +146,7 @@ class ElasticsearchClient @Inject() (
   private[this] def execute(
       request: ActionRequest
   ): Nested[Future, CircuitBreakerResult, ActionResponse] =
-    withBreakerCurried(
+    withBreaker(
       s"Error executing elasticearch query: $request due to error"
     ) {
       request match {

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchClient.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchClient.scala
@@ -9,9 +9,16 @@ import com.foreignlanguagereader.domain.client.elasticsearch.searchstates.{
   ElasticsearchSearchRequest,
   ElasticsearchSearchResponse
 }
-import com.sksamuel.elastic4s.ElasticDsl._
-import com.sksamuel.elastic4s._
 import javax.inject.{Inject, Singleton}
+import org.elasticsearch.action.bulk.BulkRequest
+import org.elasticsearch.action.index.IndexRequest
+import org.elasticsearch.action.search.{
+  MultiSearchRequest,
+  MultiSearchResponse,
+  SearchRequest
+}
+import org.elasticsearch.action.{ActionRequest, ActionResponse}
+import play.api.libs.json.Reads
 import play.api.{Configuration, Logger}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -34,25 +41,24 @@ class ElasticsearchClient @Inject() (
     * and puts a limit on the number of times we will retry a search that hasn't given us results before.
     *
     * @param requests The search requests to cache.
-    * @param hitReader Automatically generated from Reads[T]
     * @param tag The class of T, captured at runtime. This is needed to make a Seq of an arbitrary type due to JVM type erasure.
     * @tparam T A case class with Reads[T] and Writes[T]
     * @return
     */
-  def findFromCacheOrRefetch[T: Indexable](
+  def findFromCacheOrRefetch[T](
       requests: List[ElasticsearchSearchRequest[T]]
   )(implicit
-      hitReader: HitReader[T],
-      attemptsHitReader: HitReader[LookupAttempt],
-      tag: ClassTag[T]
+      tag: ClassTag[T],
+      reads: Reads[T]
   ): Future[List[List[T]]] = {
     // Fork and join for getting each request
     requests
       .traverse(request =>
         execute(request.query).value
-          .map(result =>
-            ElasticsearchSearchResponse.fromResult(request, result)
-          )
+          .map {
+            case result: CircuitBreakerResult[MultiSearchResponse] =>
+              ElasticsearchSearchResponse.fromResult(request, result)
+          }
           // This is where fetchers are called to get results if they aren't in elasticsearch
           // There is also logic to remember what has been fetched from external sources
           // So that we don't try too many times on the same query
@@ -97,7 +103,16 @@ class ElasticsearchClient @Inject() (
 
   def save(request: ElasticsearchCacheRequest): Future[Unit] = {
     logger.info(s"Saving to elasticsearch: $request")
-    val result = execute(bulk(request.requests))
+    val bulkRequest = request.requests.foldLeft(new BulkRequest()) {
+      case (acc, req) =>
+        // A little clumsy but we need to preserve whether this is an index or an update to compile.
+        // Either way, the action needed is the same.
+        req match {
+          case Left(i)  => acc.add(i)
+          case Right(u) => acc.add(u)
+        }
+    }
+    val result = execute(bulkRequest)
     val searchValue = result.value
     searchValue.map {
       case CircuitBreakerAttempt(_) =>
@@ -129,17 +144,19 @@ class ElasticsearchClient @Inject() (
   // Common wrappers for all requests below here
 
   // Unwraps all elasticsearch requests so there can be a single failure path
-  private[this] def execute[T, U](request: T)(implicit
-      handler: Handler[T, U],
-      manifest: Manifest[U]
-  ): Nested[Future, CircuitBreakerResult, U] =
-    withBreaker(
-      s"Error executing elasticearch query: $request due to error",
-      client.execute(request) map {
-        case RequestSuccess(_, _, _, result) => result
-        case RequestFailure(_, _, _, error)  => throw error.asException
+  private[this] def execute(
+      request: ActionRequest
+  ): Nested[Future, CircuitBreakerResult, ActionResponse] =
+    withBreakerCurried(
+      s"Error executing elasticearch query: $request due to error"
+    ) {
+      request match {
+        case b: BulkRequest        => client.bulk(b)
+        case i: IndexRequest       => client.index(i)
+        case m: MultiSearchRequest => client.multisearch(m)
+        case s: SearchRequest      => client.search(s)
       }
-    )
+    }
 
   // Circuit breaker stuff below here
 
@@ -147,18 +164,4 @@ class ElasticsearchClient @Inject() (
     logger.info("Retrying inserts because elasticsearch is healthy again.")
     val _ = Future.apply(startInserting())
   })
-
-  /**
-    * This makes the circuitbreaker know when elasticsearch requests are failing
-    * Without this, errors show up as successes.
-    * @param result The result to work with
-    * @tparam T Whatever the request is. Doesn't matter for this one
-    * @return Was it a failure?
-    */
-  override def defaultIsSuccess[T](result: T): Boolean =
-    result match {
-      case RequestSuccess(_, _, _, _) => true
-      case RequestFailure(_, _, _, _) => false
-      case _                          => true
-    }
 }

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchClient.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchClient.scala
@@ -14,16 +14,16 @@ import org.elasticsearch.action.bulk.BulkRequest
 import org.elasticsearch.action.index.IndexRequest
 import org.elasticsearch.action.search.{MultiSearchRequest, SearchRequest}
 import org.elasticsearch.action.{ActionRequest, ActionResponse}
+import play.api.Logger
 import play.api.libs.json._
-import play.api.{Configuration, Logger}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.reflect.ClassTag
 
 @Singleton
 class ElasticsearchClient @Inject() (
-    config: Configuration,
     val client: ElasticsearchClientHolder,
+    implicit val responseReader: ElasticsearchResponseReader,
     val system: ActorSystem
 ) extends Circuitbreaker {
   override val logger: Logger = Logger(this.getClass)
@@ -48,8 +48,6 @@ class ElasticsearchClient @Inject() (
       reads: Reads[T],
       writes: Writes[T]
   ): Future[List[List[T]]] = {
-    implicit val reader: ElasticsearchResponseReader =
-      new ElasticsearchResponseReader()
 
     // Fork and join for getting each request
     requests

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchClientHolder.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchClientHolder.scala
@@ -3,8 +3,6 @@ package com.foreignlanguagereader.domain.client.elasticsearch
 import java.util.concurrent.ConcurrentLinkedQueue
 
 import com.foreignlanguagereader.domain.client.elasticsearch.searchstates.ElasticsearchCacheRequest
-import com.sksamuel.elastic4s._
-import com.sksamuel.elastic4s.http.JavaClient
 import javax.inject.{Inject, Singleton}
 import org.apache.http.HttpHost
 import org.elasticsearch.action.bulk.{BulkRequest, BulkResponse}
@@ -29,9 +27,6 @@ import scala.collection.JavaConverters._
 @Singleton
 class ElasticsearchClientHolder @Inject() (config: Configuration) {
   val elasticSearchUrl: String = config.get[String]("elasticsearch.url")
-  val client: ElasticClient = ElasticClient(
-    JavaClient(ElasticProperties(elasticSearchUrl))
-  )
 
   val javaClient = new RestHighLevelClient(
     RestClient.builder(
@@ -58,12 +53,6 @@ class ElasticsearchClientHolder @Inject() (config: Configuration) {
       request: MultiSearchRequest
   )(implicit ec: ExecutionContext): Future[MultiSearchResponse] =
     Future { javaClient.msearch(request, RequestOptions.DEFAULT) }
-
-  def execute[T, U](request: T)(implicit
-      handler: Handler[T, U],
-      manifest: Manifest[U]
-  ): Future[Response[U]] =
-    client.execute(request)
 
   // Handles retrying of queue
 

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchClientHolder.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchClientHolder.scala
@@ -6,9 +6,23 @@ import com.foreignlanguagereader.domain.client.elasticsearch.searchstates.Elasti
 import com.sksamuel.elastic4s._
 import com.sksamuel.elastic4s.http.JavaClient
 import javax.inject.{Inject, Singleton}
+import org.apache.http.HttpHost
+import org.elasticsearch.action.bulk.{BulkRequest, BulkResponse}
+import org.elasticsearch.action.index.{IndexRequest, IndexResponse}
+import org.elasticsearch.action.search.{
+  MultiSearchRequest,
+  MultiSearchResponse,
+  SearchRequest,
+  SearchResponse
+}
+import org.elasticsearch.client.{
+  RequestOptions,
+  RestClient,
+  RestHighLevelClient
+}
 import play.api.Configuration
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.collection.JavaConverters._
 
 // Holder to enable easy mocking
@@ -18,6 +32,32 @@ class ElasticsearchClientHolder @Inject() (config: Configuration) {
   val client: ElasticClient = ElasticClient(
     JavaClient(ElasticProperties(elasticSearchUrl))
   )
+
+  val javaClient = new RestHighLevelClient(
+    RestClient.builder(
+      new HttpHost(elasticSearchUrl, 9200, "http")
+    )
+  )
+
+  def index(
+      request: IndexRequest
+  )(implicit ec: ExecutionContext): Future[IndexResponse] =
+    Future { javaClient.index(request, RequestOptions.DEFAULT) }
+
+  def bulk(
+      request: BulkRequest
+  )(implicit ec: ExecutionContext): Future[BulkResponse] =
+    Future { javaClient.bulk(request, RequestOptions.DEFAULT) }
+
+  def search(
+      request: SearchRequest
+  )(implicit ec: ExecutionContext): Future[SearchResponse] =
+    Future { javaClient.search(request, RequestOptions.DEFAULT) }
+
+  def multisearch(
+      request: MultiSearchRequest
+  )(implicit ec: ExecutionContext): Future[MultiSearchResponse] =
+    Future { javaClient.msearch(request, RequestOptions.DEFAULT) }
 
   def execute[T, U](request: T)(implicit
       handler: Handler[T, U],

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchClientHolder.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchClientHolder.scala
@@ -23,7 +23,8 @@ import play.api.Configuration
 import scala.concurrent.{ExecutionContext, Future}
 import scala.collection.JavaConverters._
 
-// Holder to enable easy mocking
+// Holder to enable easy mocking.
+// $COVERAGE-OFF$
 @Singleton
 class ElasticsearchClientHolder @Inject() (config: Configuration) {
   val elasticSearchUrl: String = config.get[String]("elasticsearch.url")
@@ -74,10 +75,8 @@ class ElasticsearchClientHolder @Inject() (config: Configuration) {
     new ConcurrentLinkedQueue()
 
   def nextInsert(): Option[ElasticsearchCacheRequest] =
-    insertionQueue.poll() match {
-      case null                            => None // scalastyle:off
-      case item: ElasticsearchCacheRequest => Some(item)
-    }
+    Option.apply(insertionQueue.poll())
 
   def hasMore: Boolean = !insertionQueue.isEmpty
 }
+// $COVERAGE-ON$

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchResponseReader.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchResponseReader.scala
@@ -5,6 +5,11 @@ import org.elasticsearch.action.search.{MultiSearchResponse, SearchResponse}
 import play.api.Logger
 import play.api.libs.json.{JsError, JsSuccess, Json, Reads}
 
+// $COVERAGE-OFF$
+// This class exists to mock results from the elasticsearch client,
+// which has been created in a way that prevents mocking.
+// The scenarios we care about is how we react to elasticsearch results,
+// not the details of the fetching
 class ElasticsearchResponseReader {
   val logger: Logger = Logger(this.getClass)
 
@@ -74,3 +79,4 @@ class ElasticsearchResponseReader {
     else { None }
   }
 }
+// $COVERAGE-ON$

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchResponseReader.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchResponseReader.scala
@@ -1,0 +1,76 @@
+package com.foreignlanguagereader.domain.client.elasticsearch
+
+import cats.implicits._
+import org.elasticsearch.action.search.{MultiSearchResponse, SearchResponse}
+import play.api.Logger
+import play.api.libs.json.{JsError, JsSuccess, Json, Reads}
+
+class ElasticsearchResponseReader {
+  val logger: Logger = Logger(this.getClass)
+
+  def getResultsFromSearch[T](response: MultiSearchResponse)(implicit
+      reads: Reads[T]
+  ): (Option[Seq[T]], Int, Option[String]) = {
+    val responses = response.getResponses
+    val results = getResultsFromMultisearchItem[T](responses.head) match {
+      case Left(hits) =>
+        Some(hits.map {
+          case (_, item) => item
+        })
+      case Right(_) => None
+    }
+    val (attemptsCount, attemptsId) =
+      getResultsFromMultisearchItem[LookupAttempt](responses.tail.head) match {
+        case Left(a) =>
+          val (id, attempt) = a.head
+          (attempt.count, Some(id))
+        case Right(_) => (0, None)
+      }
+
+    (results, attemptsCount, attemptsId)
+  }
+
+  def getResultsFromMultisearchItem[T](
+      item: MultiSearchResponse.Item
+  )(implicit reads: Reads[T]): Either[Seq[(String, T)], Exception] = {
+    if (item.isFailure) {
+      logger.error(
+        s"Failed to get request count from elasticsearch due to error ${item.getFailureMessage}",
+        item.getFailure
+      )
+      item.getFailure.asRight
+    } else {
+      getHitsFrom(item.getResponse) match {
+        case Some(results) => results.asLeft
+        case None =>
+          new IllegalStateException(
+            "Failed to parse json from elasticsearch"
+          ).asRight
+      }
+    }
+  }
+
+  def getHitsFrom[T](
+      response: SearchResponse
+  )(implicit reads: Reads[T]): Option[Seq[(String, T)]] = {
+    val r = response.getHits.getHits
+      .map(hit =>
+        Json.parse(hit.getSourceAsString).validate[T] match {
+          case JsSuccess(value, _) => Some((hit.getId, value))
+          case JsError(errors) =>
+            val errs = errors
+              .map {
+                case (path, e) => s"At path $path: ${e.mkString(", ")}"
+              }
+              .mkString("\n")
+            logger.error(
+              s"Failed to parse results from elasticsearch due to errors: $errs"
+            )
+            None
+        }
+      )
+
+    if (r.forall(_.isDefined)) { Some(r.flatten.toList) }
+    else { None }
+  }
+}

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/searchstates/ElasticsearchCacheRequest.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/searchstates/ElasticsearchCacheRequest.scala
@@ -1,10 +1,12 @@
 package com.foreignlanguagereader.domain.client.elasticsearch.searchstates
 
 import cats.implicits._
-import com.sksamuel.elastic4s.requests.bulk.BulkCompatibleRequest
+import org.elasticsearch.action.ActionRequest
+import org.elasticsearch.action.index.IndexRequest
+import org.elasticsearch.action.update.UpdateRequest
 
 case class ElasticsearchCacheRequest(
-    requests: List[BulkCompatibleRequest],
+    requests: List[Either[IndexRequest, UpdateRequest]],
     retried: Boolean = false
 ) {
 
@@ -24,7 +26,7 @@ case class ElasticsearchCacheRequest(
 object ElasticsearchCacheRequest {
   val maxConcurrentInserts = 5
   def fromRequests(
-      requests: List[BulkCompatibleRequest]
+      requests: List[Either[IndexRequest, UpdateRequest]]
   ): List[ElasticsearchCacheRequest] = {
     requests
       .grouped(maxConcurrentInserts)

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/searchstates/ElasticsearchSearchResponse.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/searchstates/ElasticsearchSearchResponse.scala
@@ -51,8 +51,13 @@ case class ElasticsearchSearchResponse[T](
   ) =
     response match {
       case CircuitBreakerAttempt(r) =>
-        val (result, attempts, id) = reader.getResultsFromSearch(r)
-        (result, attempts, id, true)
+        val (results, attempts, id) = reader.getResultsFromSearch(r)
+        // Done to make us refetch
+        val actualResults = results match {
+          case Some(r) if r.nonEmpty => Some(r)
+          case _                     => None
+        }
+        (actualResults, attempts, id, true)
       case _ =>
         (None, 0, None, false)
     }

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/searchstates/ElasticsearchSearchResult.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/elasticsearch/searchstates/ElasticsearchSearchResult.scala
@@ -59,7 +59,7 @@ case class ElasticsearchSearchResult[T: Writes](
         case None =>
           new IndexRequest()
             .source(Json.toJson(attempt).toString(), XContentType.JSON)
-            .index(index)
+            .index(attemptsIndex)
             .asLeft
             .some
       }

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/google/GoogleCloudClient.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/google/GoogleCloudClient.scala
@@ -65,8 +65,7 @@ class GoogleCloudClient @Inject() (
       .setEncodingType(EncodingType.UTF16)
       .build
 
-    withBreaker(
-      s"Failed to get tokens from google cloud",
+    withBreaker(s"Failed to get tokens from google cloud")(
       Future {
         gcloud.getTokens(request)
       }

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/client/google/GoogleLanguageServiceClientHolder.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/client/google/GoogleLanguageServiceClientHolder.scala
@@ -10,6 +10,7 @@ import javax.inject.Singleton
 
 import scala.collection.JavaConverters._
 
+// $COVERAGE-OFF$
 /**
   * Holder for the google cloud client.
   * Allows us to swap this out for testing
@@ -25,3 +26,4 @@ class GoogleLanguageServiceClientHolder {
   def getTokens(request: AnalyzeSyntaxRequest): List[Token] =
     analyzeSyntax(request).getTokensList.asScala.toList
 }
+// $COVERAGE-ON$

--- a/domain/src/main/scala/com/foreignlanguagereader/domain/service/definition/LanguageDefinitionService.scala
+++ b/domain/src/main/scala/com/foreignlanguagereader/domain/service/definition/LanguageDefinitionService.scala
@@ -17,7 +17,6 @@ import com.foreignlanguagereader.content.types.internal.definition.{
 }
 import com.foreignlanguagereader.content.types.internal.definition.DefinitionSource.DefinitionSource
 import com.foreignlanguagereader.domain.client.LanguageServiceClient
-import com.sksamuel.elastic4s.playjson._
 import play.api.Logger
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchClientTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/client/elasticsearch/ElasticsearchClientTest.scala
@@ -1,6 +1,7 @@
 package com.foreignlanguagereader.domain.client.elasticsearch
 
 import akka.actor.ActorSystem
+import cats.implicits._
 import com.foreignlanguagereader.content.types.Language
 import com.foreignlanguagereader.content.types.internal.definition.{
   Definition,
@@ -14,16 +15,10 @@ import com.foreignlanguagereader.domain.client.elasticsearch.searchstates.{
   ElasticsearchSearchRequest
 }
 import com.foreignlanguagereader.domain.util.ElasticsearchTestUtil
-import com.sksamuel.elastic4s.ElasticDsl.{bulk, indexInto}
-import com.sksamuel.elastic4s._
-import com.sksamuel.elastic4s.playjson._
-import com.sksamuel.elastic4s.requests.bulk.{BulkRequest, BulkResponse}
-import com.sksamuel.elastic4s.requests.searches.{
-  MultiSearchRequest,
-  MultiSearchResponse
-}
 import com.typesafe.config.ConfigFactory
-import org.mockito.ArgumentMatchers.{any, eq => mockitoEq}
+import org.elasticsearch.action.bulk.{BulkRequest, BulkResponse}
+import org.elasticsearch.action.search.{MultiSearchRequest, MultiSearchResponse}
+import org.mockito.ArgumentMatchers.any
 import org.mockito.{Mockito, MockitoSugar}
 import org.scalatest.FutureOutcome
 import org.scalatest.funspec.AsyncFunSpec
@@ -57,10 +52,6 @@ class ElasticsearchClientTest extends AsyncFunSpec with MockitoSugar {
 
   // These are necessary to avoid having to manually create the results.
   // They are pulled into ElasticsearchTestUtil.cacheQueryResponseFrom, and given the appropriate responses.
-  implicit val definitionHitReader: HitReader[Definition] =
-    mock[HitReader[Definition]]
-  implicit val attemptsHitReader: HitReader[LookupAttempt] =
-    mock[HitReader[LookupAttempt]]
 
   override def withFixture(test: NoArgAsyncTest): FutureOutcome = {
     Mockito.reset(holder)
@@ -71,18 +62,13 @@ class ElasticsearchClientTest extends AsyncFunSpec with MockitoSugar {
     it("can fetch results from a cache") {
       val response: MultiSearchResponse = ElasticsearchTestUtil
         .cacheQueryResponseFrom[Definition](
-          Right(List(fetchedDefinition)),
-          Right(attemptsRefreshEligible)
+          Some(List(fetchedDefinition)),
+          Some(attemptsRefreshEligible)
         )
       when(
-        holder.execute[MultiSearchRequest, MultiSearchResponse](
-          any(classOf[MultiSearchRequest])
-        )(
-          any(classOf[Handler[MultiSearchRequest, MultiSearchResponse]]),
-          any(classOf[Manifest[MultiSearchResponse]])
-        )
+        holder.multisearch(any(classOf[MultiSearchRequest]))
       ).thenReturn(
-        Future.successful(RequestSuccess(200, None, Map(), response))
+        Future.successful(response)
       )
 
       client
@@ -108,18 +94,15 @@ class ElasticsearchClientTest extends AsyncFunSpec with MockitoSugar {
     it("can handle cache misses") {
       val response: MultiSearchResponse = ElasticsearchTestUtil
         .cacheQueryResponseFrom[Definition](
-          Right(List()),
-          Right(attemptsRefreshEligible)
+          Some(List()),
+          Some(attemptsRefreshEligible)
         )
       when(
-        holder.execute[MultiSearchRequest, MultiSearchResponse](
+        holder.multisearch(
           any(classOf[MultiSearchRequest])
-        )(
-          any(classOf[Handler[MultiSearchRequest, MultiSearchResponse]]),
-          any(classOf[Manifest[MultiSearchResponse]])
         )
       ).thenReturn(
-        Future.successful(RequestSuccess(200, None, Map(), response))
+        Future.successful(response)
       )
 
       client
@@ -146,30 +129,10 @@ class ElasticsearchClientTest extends AsyncFunSpec with MockitoSugar {
     describe("gracefully handles failures") {
       it("can handle failures when searching from elasticsearch") {
         when(
-          holder.execute[MultiSearchRequest, MultiSearchResponse](
+          holder.multisearch(
             any(classOf[MultiSearchRequest])
-          )(
-            any(classOf[Handler[MultiSearchRequest, MultiSearchResponse]]),
-            any(classOf[Manifest[MultiSearchResponse]])
           )
-        ).thenReturn(
-          Future.successful(
-            RequestFailure(
-              200,
-              None,
-              Map(),
-              new ElasticError(
-                "",
-                "You messed up",
-                None,
-                None,
-                None,
-                List(),
-                None
-              )
-            )
-          )
-        )
+        ).thenThrow(new IllegalStateException("Uh oh"))
 
         client
           .findFromCacheOrRefetch[Definition](
@@ -196,8 +159,8 @@ class ElasticsearchClientTest extends AsyncFunSpec with MockitoSugar {
     describe("can save") {
       val indexRequests = (1 to 5)
         .map(number =>
-          indexInto("attempts")
-            .doc(
+          ElasticsearchTestUtil
+            .lookupIndexRequestFrom(
               LookupAttempt(
                 index = "test",
                 fields = Map(
@@ -207,6 +170,7 @@ class ElasticsearchClientTest extends AsyncFunSpec with MockitoSugar {
                 count = number
               )
             )
+            .asLeft
         )
         .toList
       val requests = ElasticsearchCacheRequest.fromRequests(indexRequests)
@@ -214,20 +178,9 @@ class ElasticsearchClientTest extends AsyncFunSpec with MockitoSugar {
 
       it("can save correctly") {
         when(
-          holder.execute[BulkRequest, BulkResponse](any(classOf[BulkRequest]))(
-            any(classOf[Handler[BulkRequest, BulkResponse]]),
-            any(classOf[Manifest[BulkResponse]])
-          )
+          holder.bulk(any(classOf[BulkRequest]))
         ).thenReturn(
-          Future
-            .successful(
-              RequestSuccess(
-                200,
-                None,
-                Map(),
-                BulkResponse(0, errors = false, List())
-              )
-            )
+          Future.successful(mock[BulkResponse])
         )
 
         client
@@ -240,30 +193,10 @@ class ElasticsearchClientTest extends AsyncFunSpec with MockitoSugar {
       }
       ignore("retries requests one by one if bulk requests failed") {
         when(
-          holder.execute[BulkRequest, BulkResponse](
-            mockitoEq[BulkRequest](bulk(request.requests))
-          )(
-            any(classOf[Handler[BulkRequest, BulkResponse]]),
-            any(classOf[Manifest[BulkResponse]])
+          holder.bulk(
+            any(classOf[BulkRequest])
           )
-        ).thenReturn(
-          Future.successful(
-            RequestFailure(
-              200,
-              None,
-              Map(),
-              new ElasticError(
-                "",
-                "Please try again",
-                None,
-                None,
-                None,
-                List(),
-                None
-              )
-            )
-          )
-        )
+        ).thenThrow(new IllegalStateException("Please try again"))
 
         client
           .save(request)

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/client/elasticsearch/searchstates/ElasticsearchCacheRequestTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/client/elasticsearch/searchstates/ElasticsearchCacheRequestTest.scala
@@ -1,26 +1,24 @@
 package com.foreignlanguagereader.domain.client.elasticsearch.searchstates
 
+import cats.implicits._
 import com.foreignlanguagereader.domain.client.elasticsearch.LookupAttempt
-import com.sksamuel.elastic4s.ElasticDsl.indexInto
-import com.sksamuel.elastic4s.playjson._
+import com.foreignlanguagereader.domain.util.ElasticsearchTestUtil
 import org.scalatest.funspec.AnyFunSpec
 
 class ElasticsearchCacheRequestTest extends AnyFunSpec {
   describe("an elasticsearch cache request") {
     val indexRequests = (1 to 10)
-      .map(number =>
-        indexInto("attempts")
-          .doc(
-            LookupAttempt(
-              index = "test",
-              fields = Map(
-                s"Field ${1 * number}" -> s"Value ${1 * number}",
-                s"Field ${2 * number}" -> s"Value ${2 * number}"
-              ),
-              count = number
-            )
-          )
-      )
+      .map(number => {
+        val attempt = LookupAttempt(
+          index = "test",
+          fields = Map(
+            s"Field ${1 * number}" -> s"Value ${1 * number}",
+            s"Field ${2 * number}" -> s"Value ${2 * number}"
+          ),
+          count = number
+        )
+        ElasticsearchTestUtil.lookupIndexRequestFrom(attempt).asLeft
+      })
       .toList
     val requests = ElasticsearchCacheRequest.fromRequests(indexRequests)
 

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/client/elasticsearch/searchstates/ElasticsearchSearchResultTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/client/elasticsearch/searchstates/ElasticsearchSearchResultTest.scala
@@ -1,6 +1,5 @@
 package com.foreignlanguagereader.domain.client.elasticsearch.searchstates
 
-import cats.implicits._
 import com.foreignlanguagereader.content.types.Language
 import com.foreignlanguagereader.content.types.internal.definition.{
   ChineseDefinition,
@@ -11,12 +10,14 @@ import com.foreignlanguagereader.content.types.internal.definition.{
 import com.foreignlanguagereader.content.types.internal.word.PartOfSpeech
 import com.foreignlanguagereader.domain.client.elasticsearch.LookupAttempt
 import com.foreignlanguagereader.domain.util.ElasticsearchTestUtil
+import org.elasticsearch.action.index.IndexRequest
 import org.scalatest.funspec.AnyFunSpec
 
 class ElasticsearchSearchResultTest extends AnyFunSpec {
   val index: String = "definition"
   val fields: Map[String, String] =
     Map("field1" -> "value1", "field2" -> "value2", "field3" -> "value3")
+
   describe("an elasticsearch result") {
     describe("where nothing was refetched") {
       it("does not persist anything to elasticsearch") {
@@ -51,16 +52,16 @@ class ElasticsearchSearchResultTest extends AnyFunSpec {
           LookupAttempt(index, fields, 5)
         )
       it("correctly saves fetch attempts to elasticsearch") {
-        assert(result.updateAttemptsQuery.contains(attemptsQuery.asLeft))
+        assert(
+          result.updateAttemptsQuery.isDefined && result.updateAttemptsQuery.get.isLeft
+        )
+        val updateQuery = result.updateAttemptsQuery.get.left.get
+        assert(updateQuery.indices().contains("attempts"))
+        assert(updateQuery.sourceAsMap() == attemptsQuery.sourceAsMap())
       }
       it("does not cache anything") {
         assert(result.cacheQueries.isEmpty)
-        assert(
-          result.toIndex
-            .contains(
-              List(ElasticsearchCacheRequest(List(attemptsQuery.asLeft)))
-            )
-        )
+        assert(result.toIndex.isDefined && result.toIndex.get.length == 1)
       }
     }
 
@@ -86,6 +87,11 @@ class ElasticsearchSearchResultTest extends AnyFunSpec {
       token = "anything"
     )
 
+    val chineseDefinitionRequest =
+      ElasticsearchTestUtil.indexRequestFrom(index, dummyChineseDefinition)
+    val genericDefinitionRequest =
+      ElasticsearchTestUtil.indexRequestFrom(index, dummyGenericDefinition)
+
     describe("on a previously untried query") {
       val result = ElasticsearchSearchResult[Definition](
         index = index,
@@ -100,26 +106,46 @@ class ElasticsearchSearchResultTest extends AnyFunSpec {
         ElasticsearchTestUtil.lookupIndexRequestFrom(
           LookupAttempt(index, fields, 1)
         )
-      val indexQuery = List(
-        ElasticsearchTestUtil
-          .indexRequestFrom(index, dummyChineseDefinition)
-          .asLeft,
-        ElasticsearchTestUtil
-          .indexRequestFrom(index, dummyGenericDefinition)
-          .asLeft
-      )
+
       it("creates a new fetch attempt in elasticsearch") {
-        assert(result.updateAttemptsQuery.contains(attemptsQuery.asLeft))
+        assert(result.updateAttemptsQuery.isDefined)
+        assert(result.updateAttemptsQuery.get.isLeft)
+
+        val fetchAttempt: IndexRequest = result.updateAttemptsQuery.get.left.get
+        assert(fetchAttempt.indices().contains("attempts"))
+        assert(fetchAttempt.sourceAsMap() == attemptsQuery.sourceAsMap())
       }
+
       it("caches search results to elasticsearch") {
-        assert(result.cacheQueries.contains(indexQuery))
+        assert(result.cacheQueries.isDefined)
+        val cacheQueriesEither = result.cacheQueries.get
+
+        assert(cacheQueriesEither.forall(_.isLeft))
+        val cacheQueries = cacheQueriesEither.map(_.left.get)
+
+        assert(cacheQueries.forall(_.indices().contains(index)))
         assert(
-          result.toIndex
-            .contains(
-              List(
-                ElasticsearchCacheRequest(attemptsQuery.asLeft :: indexQuery)
-              )
-            )
+          cacheQueries
+            .exists(_.sourceAsMap() == chineseDefinitionRequest.sourceAsMap())
+        )
+        assert(
+          cacheQueries
+            .exists(_.sourceAsMap() == genericDefinitionRequest.sourceAsMap())
+        )
+
+        val indexQueries: Seq[IndexRequest] =
+          result.toIndex.get.flatMap(a => a.requests).map(_.left.get)
+        assert(indexQueries.length == 3)
+        assert(
+          indexQueries.exists(_.sourceAsMap() == attemptsQuery.sourceAsMap())
+        )
+        assert(
+          indexQueries
+            .exists(_.sourceAsMap() == chineseDefinitionRequest.sourceAsMap())
+        )
+        assert(
+          indexQueries
+            .exists(_.sourceAsMap() == genericDefinitionRequest.sourceAsMap())
         )
       }
     }
@@ -143,27 +169,59 @@ class ElasticsearchSearchResultTest extends AnyFunSpec {
             attemptsId,
             LookupAttempt(index = index, fields = fields, count = 2)
           )
-          .asRight
 
-      val indexQuery = List(
-        ElasticsearchTestUtil
-          .indexRequestFrom(index, dummyChineseDefinition)
-          .asLeft,
-        ElasticsearchTestUtil
-          .indexRequestFrom(index, dummyGenericDefinition)
-          .asLeft
-      )
       it("updates the previous fetch attempt in elasticsearch") {
-        assert(result.updateAttemptsQuery.contains(attemptsQuery))
+        assert(
+          result.updateAttemptsQuery.isDefined && result.updateAttemptsQuery.get.isRight
+        )
+        val updateQuery = result.updateAttemptsQuery.get.right.get
+        assert(updateQuery.indices().contains("attempts"))
+        assert(
+          updateQuery.upsertRequest().sourceAsMap() == attemptsQuery
+            .upsertRequest()
+            .sourceAsMap()
+        )
       }
       it("caches search results to elasticsearch") {
-        assert(result.cacheQueries.contains(indexQuery))
+        assert(result.cacheQueries.isDefined)
+        val cacheQueriesEither = result.cacheQueries.get
+
+        assert(cacheQueriesEither.forall(_.isLeft))
+        val cacheQueries = cacheQueriesEither.map(_.left.get)
+
+        assert(cacheQueries.forall(_.indices().contains(index)))
         assert(
-          result.toIndex
-            .contains(
-              List(ElasticsearchCacheRequest(attemptsQuery :: indexQuery))
-            )
+          cacheQueries
+            .exists(_.sourceAsMap() == chineseDefinitionRequest.sourceAsMap())
         )
+        assert(
+          cacheQueries
+            .exists(_.sourceAsMap() == genericDefinitionRequest.sourceAsMap())
+        )
+
+        val (indexQueries, updateQueries) = {
+          val (i, u) = result.toIndex.get
+            .flatMap(a => a.requests)
+            .partition(_.isLeft)
+          (i.map(_.left.get), u.map(_.right.get))
+        }
+        assert(indexQueries.length == 2)
+        assert(
+          indexQueries
+            .exists(_.sourceAsMap() == chineseDefinitionRequest.sourceAsMap())
+        )
+        assert(
+          indexQueries
+            .exists(_.sourceAsMap() == genericDefinitionRequest.sourceAsMap())
+        )
+
+        assert(updateQueries.length == 1)
+        assert(
+          updateQueries.head.upsertRequest().sourceAsMap() == attemptsQuery
+            .upsertRequest()
+            .sourceAsMap()
+        )
+
       }
     }
   }

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/service/definition/ChineseDefinitionServiceTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/service/definition/ChineseDefinitionServiceTest.scala
@@ -12,15 +12,12 @@ import com.foreignlanguagereader.content.types.internal.word.{
   Word
 }
 import com.foreignlanguagereader.domain.client.LanguageServiceClient
+import com.foreignlanguagereader.domain.client.elasticsearch.ElasticsearchClient
 import com.foreignlanguagereader.domain.client.elasticsearch.searchstates.ElasticsearchSearchRequest
-import com.foreignlanguagereader.domain.client.elasticsearch.{
-  ElasticsearchClient,
-  LookupAttempt
-}
-import com.sksamuel.elastic4s.{HitReader, Indexable}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.MockitoSugar
 import org.scalatest.funspec.AsyncFunSpec
+import play.api.libs.json.{Reads, Writes}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.reflect.ClassTag
@@ -99,10 +96,9 @@ class ChineseDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
           .findFromCacheOrRefetch[Definition](
             any(classOf[List[ElasticsearchSearchRequest[Definition]]])
           )(
-            any(classOf[Indexable[Definition]]),
-            any(classOf[HitReader[Definition]]),
-            any(classOf[HitReader[LookupAttempt]]),
-            any(classOf[ClassTag[Definition]])
+            any(classOf[ClassTag[Definition]]),
+            any(classOf[Reads[Definition]]),
+            any(classOf[Writes[Definition]])
           )
       ).thenReturn(
         Future.successful(
@@ -126,10 +122,9 @@ class ChineseDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
             .findFromCacheOrRefetch(
               any(classOf[List[ElasticsearchSearchRequest[Definition]]])
             )(
-              any(classOf[Indexable[Definition]]),
-              any(classOf[HitReader[Definition]]),
-              any(classOf[HitReader[LookupAttempt]]),
-              any(classOf[ClassTag[Definition]])
+              any(classOf[ClassTag[Definition]]),
+              any(classOf[Reads[Definition]]),
+              any(classOf[Writes[Definition]])
             )
         ).thenReturn(
           Future.successful(List(List(dummyCedictDefinition), List()))
@@ -151,10 +146,9 @@ class ChineseDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
             .findFromCacheOrRefetch(
               any(classOf[List[ElasticsearchSearchRequest[Definition]]])
             )(
-              any(classOf[Indexable[Definition]]),
-              any(classOf[HitReader[Definition]]),
-              any(classOf[HitReader[LookupAttempt]]),
-              any(classOf[ClassTag[Definition]])
+              any(classOf[ClassTag[Definition]]),
+              any(classOf[Reads[Definition]]),
+              any(classOf[Writes[Definition]])
             )
         ).thenReturn(
           Future.successful(List(List(), List(dummyWiktionaryDefinition)))
@@ -174,10 +168,9 @@ class ChineseDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
             .findFromCacheOrRefetch(
               any(classOf[List[ElasticsearchSearchRequest[Definition]]])
             )(
-              any(classOf[Indexable[Definition]]),
-              any(classOf[HitReader[Definition]]),
-              any(classOf[HitReader[LookupAttempt]]),
-              any(classOf[ClassTag[Definition]])
+              any(classOf[ClassTag[Definition]]),
+              any(classOf[Reads[Definition]]),
+              any(classOf[Writes[Definition]])
             )
         ).thenReturn(
           Future.successful(
@@ -224,10 +217,9 @@ class ChineseDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
             .findFromCacheOrRefetch(
               any(classOf[List[ElasticsearchSearchRequest[Definition]]])
             )(
-              any(classOf[Indexable[Definition]]),
-              any(classOf[HitReader[Definition]]),
-              any(classOf[HitReader[LookupAttempt]]),
-              any(classOf[ClassTag[Definition]])
+              any(classOf[ClassTag[Definition]]),
+              any(classOf[Reads[Definition]]),
+              any(classOf[Writes[Definition]])
             )
         ).thenReturn(
           Future.successful(

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/service/definition/LanguageDefinitionServiceTest.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/service/definition/LanguageDefinitionServiceTest.scala
@@ -16,16 +16,12 @@ import com.foreignlanguagereader.content.types.internal.word.{
 }
 import com.foreignlanguagereader.domain.client.LanguageServiceClient
 import com.foreignlanguagereader.domain.client.common.CircuitBreakerResult
+import com.foreignlanguagereader.domain.client.elasticsearch.ElasticsearchClient
 import com.foreignlanguagereader.domain.client.elasticsearch.searchstates.ElasticsearchSearchRequest
-import com.foreignlanguagereader.domain.client.elasticsearch.{
-  ElasticsearchClient,
-  LookupAttempt
-}
-import com.sksamuel.elastic4s.{HitReader, Indexable}
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito._
 import org.mockito.MockitoSugar
 import org.scalatest.funspec.AsyncFunSpec
+import play.api.libs.json.{Reads, Writes}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.reflect.ClassTag
@@ -67,10 +63,9 @@ class LanguageDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
           .findFromCacheOrRefetch(
             any(classOf[List[ElasticsearchSearchRequest[Definition]]])
           )(
-            any(classOf[Indexable[Definition]]),
-            any(classOf[HitReader[Definition]]),
-            any(classOf[HitReader[LookupAttempt]]),
-            any(classOf[ClassTag[Definition]])
+            any(classOf[ClassTag[Definition]]),
+            any(classOf[Reads[Definition]]),
+            any(classOf[Writes[Definition]])
           )
       ).thenReturn(
         Future
@@ -97,10 +92,9 @@ class LanguageDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
           .findFromCacheOrRefetch(
             any(classOf[List[ElasticsearchSearchRequest[Definition]]])
           )(
-            any(classOf[Indexable[Definition]]),
-            any(classOf[HitReader[Definition]]),
-            any(classOf[HitReader[LookupAttempt]]),
-            any(classOf[ClassTag[Definition]])
+            any(classOf[ClassTag[Definition]]),
+            any(classOf[Reads[Definition]]),
+            any(classOf[Writes[Definition]])
           )
       ).thenReturn(Future.successful(List(List())))
 
@@ -117,10 +111,9 @@ class LanguageDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
           .findFromCacheOrRefetch(
             any(classOf[List[ElasticsearchSearchRequest[Definition]]])
           )(
-            any(classOf[Indexable[Definition]]),
-            any(classOf[HitReader[Definition]]),
-            any(classOf[HitReader[LookupAttempt]]),
-            any(classOf[ClassTag[Definition]])
+            any(classOf[ClassTag[Definition]]),
+            any(classOf[Reads[Definition]]),
+            any(classOf[Writes[Definition]])
           )
       ).thenReturn(Future.successful(List(List())))
       when(
@@ -149,10 +142,9 @@ class LanguageDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
           .findFromCacheOrRefetch(
             any(classOf[List[ElasticsearchSearchRequest[Definition]]])
           )(
-            any(classOf[Indexable[Definition]]),
-            any(classOf[HitReader[Definition]]),
-            any(classOf[HitReader[LookupAttempt]]),
-            any(classOf[ClassTag[Definition]])
+            any(classOf[ClassTag[Definition]]),
+            any(classOf[Reads[Definition]]),
+            any(classOf[Writes[Definition]])
           )
       ).thenReturn(Future.successful(List(List())))
 
@@ -217,10 +209,9 @@ class LanguageDefinitionServiceTest extends AsyncFunSpec with MockitoSugar {
             .findFromCacheOrRefetch(
               any(classOf[List[ElasticsearchSearchRequest[Definition]]])
             )(
-              any(classOf[Indexable[Definition]]),
-              any(classOf[HitReader[Definition]]),
-              any(classOf[HitReader[LookupAttempt]]),
-              any(classOf[ClassTag[Definition]])
+              any(classOf[ClassTag[Definition]]),
+              any(classOf[Reads[Definition]]),
+              any(classOf[Writes[Definition]])
             )
         ).thenReturn(
           Future.successful(

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/util/ElasticsearchTestUtil.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/util/ElasticsearchTestUtil.scala
@@ -2,68 +2,14 @@ package com.foreignlanguagereader.domain.util
 
 import com.foreignlanguagereader.domain.client.elasticsearch.LookupAttempt
 import org.elasticsearch.action.index.IndexRequest
-import org.elasticsearch.action.search.{MultiSearchResponse, SearchResponse}
 import org.elasticsearch.action.update.UpdateRequest
 import org.elasticsearch.common.xcontent.XContentType
-import org.elasticsearch.search.{SearchHit, SearchHits}
-import org.mockito.Mockito.{mock, when}
 import play.api.libs.json.{Json, Writes}
 
 /**
   * Helper library to get rid of boilerplate when testing elasticsearch responses
   */
 object ElasticsearchTestUtil {
-  def getSearchResponseFrom[T](
-      items: Seq[T]
-  )(implicit writes: Writes[T]): SearchResponse = {
-    def hits = mock(classOf[SearchHits])
-    when(hits.getHits)
-      .thenReturn(items.map(item => searchHitFrom(item)).toArray)
-
-    def response = mock(classOf[SearchResponse])
-    when(response.getHits).thenReturn(hits)
-
-    response
-  }
-
-  def searchHitFrom[T](item: T)(implicit writes: Writes[T]): SearchHit = {
-    val hit = mock(classOf[SearchHit])
-    when(hit.getSourceAsString).thenReturn(Json.toJson(item).toString())
-    hit
-  }
-
-  def getMultiSearchItemFrom[T](
-      items: Seq[T]
-  )(implicit writes: Writes[T]): MultiSearchResponse.Item = {
-    val item = mock(classOf[MultiSearchResponse.Item])
-    when(item.isFailure).thenReturn(false)
-    when(item.getResponse).thenReturn(getSearchResponseFrom(items))
-    item
-  }
-
-  def getFailedMultiSearchItem: MultiSearchResponse.Item = {
-    val item = mock(classOf[MultiSearchResponse.Item])
-    when(item.isFailure).thenReturn(true)
-    item
-  }
-
-  def cacheQueryResponseFrom[T](
-      results: Option[Seq[T]],
-      attempts: Option[LookupAttempt]
-  )(implicit writes: Writes[T]): MultiSearchResponse = {
-    val resultsResponse = results
-      .map(r => getMultiSearchItemFrom(r))
-      .getOrElse(getFailedMultiSearchItem)
-    val attemptsResponse = attempts
-      .map(a => getMultiSearchItemFrom(Array(a)))
-      .getOrElse(getFailedMultiSearchItem)
-
-    val response = mock(classOf[MultiSearchResponse])
-    when(response.getResponses)
-      .thenReturn(Array(resultsResponse, attemptsResponse))
-    response
-  }
-
   def lookupIndexRequestFrom(attempt: LookupAttempt): IndexRequest = {
     indexRequestFrom("attempts", attempt)
   }

--- a/domain/src/test/scala/com/foreignlanguagereader/domain/util/ElasticsearchTestUtil.scala
+++ b/domain/src/test/scala/com/foreignlanguagereader/domain/util/ElasticsearchTestUtil.scala
@@ -9,14 +9,10 @@ import org.elasticsearch.search.{SearchHit, SearchHits}
 import org.mockito.Mockito.{mock, when}
 import play.api.libs.json.{Json, Writes}
 
-import scala.util.Random
-
 /**
   * Helper library to get rid of boilerplate when testing elasticsearch responses
   */
 object ElasticsearchTestUtil {
-  val random = new Random()
-
   def getSearchResponseFrom[T](
       items: Seq[T]
   )(implicit writes: Writes[T]): SearchResponse = {
@@ -84,6 +80,6 @@ object ElasticsearchTestUtil {
   ): IndexRequest = {
     new IndexRequest()
       .index(index)
-      .source(Json.toJson(item).toString())
+      .source(Json.toJson(item).toString(), XContentType.JSON)
   }
 }


### PR DESCRIPTION
This will make it easier for us to keep up with the latest elasticsearch server versions. If we used elastic4s then the server versions we can use are tied to our scala version. 