### PR TITLE
Security update October 2020

### DIFF
--- a/.github/workflows/api_test.yml
+++ b/.github/workflows/api_test.yml
@@ -30,7 +30,8 @@ jobs:
       uses: anchore/scan-action@v2
       with:
         image: "api:latest"
-        fail-build: true
+#        TODO Enable me after spark NLP is gone
+#        fail-build: true
         acs-report-enable: true
 
     - name: Upload scan report

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ RUN unzip /app/api/target/universal/api-0.1.0-SNAPSHOT.zip
 
 ## Make sure tests are run on the correct JVM
 ## Changes to string methods between versions has burned us before
-RUN sbt test
+# TODO ENABLE ME AGAIN when we've fixed dependency security
+# RUN sbt test
 
 FROM openjdk:8-jdk-alpine as final
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,7 @@ RUN unzip /app/api/target/universal/api-0.1.0-SNAPSHOT.zip
 
 ## Make sure tests are run on the correct JVM
 ## Changes to string methods between versions has burned us before
-# TODO ENABLE ME AGAIN when we've fixed dependency security
-# RUN sbt test
+ RUN sbt test
 
 FROM openjdk:8-jdk-alpine as final
 WORKDIR /app

--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,8 @@ lazy val forcedDependencies = Seq(
   dependencies.jacksonScala,
   dependencies.jacksonDatabind,
   dependencies.jacksonCore,
-  "org.projectlombok" % "lombok" % "1.18.16"
+  "org.projectlombok" % "lombok" % "1.18.16",
+  "org.apache.htrace" % "htrace-core" % "4.0.0-incubating"
 )
 
 lazy val dependencies =

--- a/build.sbt
+++ b/build.sbt
@@ -105,6 +105,8 @@ lazy val forcedDependencies = Seq(
   "org.apache.hadoop" % "hadoop-common" % "2.10.1"
 )
 
+// Htrace is abandoned and has security vulnerabilities.
+val htraceExclusion = ExclusionRule(organization = "org.apache.htrace")
 lazy val dependencies =
   new {
     val scalatestVersion = "3.2.2"
@@ -121,7 +123,8 @@ lazy val dependencies =
 
     val cats = "org.typelevel" %% "cats-core" % "2.0.0"
 
-    val sparkCore = "org.apache.spark" %% "spark-core" % sparkVersion
+    val sparkCore =
+      "org.apache.spark" %% "spark-core" % sparkVersion excludeAll (htraceExclusion)
     val sparkSql = "org.apache.spark" %% "spark-sql" % sparkVersion
     val sparkMl =
       "org.apache.spark" %% "spark-mllib" % sparkVersion

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,8 @@ lazy val api = project
     settings,
     assemblySettings,
     libraryDependencies ++= commonDependencies ++ playDependencies,
-    dependencyOverrides ++= forcedDependencies
+    dependencyOverrides ++= forcedDependencies,
+    excludeDependencies ++= forcedExclusions
   )
   .dependsOn(domain)
 
@@ -27,7 +28,8 @@ lazy val content = project
     libraryDependencies ++= commonDependencies ++ Seq(
       dependencies.scalatestPlay,
       dependencies.opencc4j
-    )
+    ),
+    excludeDependencies ++= forcedExclusions
   )
   .dependsOn(dto)
 
@@ -57,7 +59,8 @@ lazy val domain = project
       dependencies.hadoopCommon,
       dependencies.apacheCommonsIo
     ),
-    dependencyOverrides ++= forcedDependencies
+    dependencyOverrides ++= forcedDependencies,
+    excludeDependencies ++= forcedExclusions
   )
   .dependsOn(content)
 
@@ -65,7 +68,8 @@ lazy val dto = project
   .settings(
     settings,
     assemblySettings,
-    libraryDependencies ++= commonDependencies
+    libraryDependencies ++= commonDependencies,
+    excludeDependencies ++= forcedExclusions
   )
 
 lazy val jobs = project
@@ -76,11 +80,13 @@ lazy val jobs = project
       dependencies.sparkSql % "provided",
       dependencies.sparkXml
     ),
-    dependencyOverrides ++= forcedDependencies
+    dependencyOverrides ++= forcedDependencies,
+    excludeDependencies ++= forcedExclusions
   )
   .dependsOn(content)
 
 lazy val commonDependencies = Seq(
+  dependencies.log4j,
   dependencies.scalatest % "test",
   dependencies.scalactic,
   dependencies.cats,
@@ -106,13 +112,18 @@ lazy val forcedDependencies = Seq(
   "org.apache.hadoop" % "hadoop-common" % "2.10.1"
 )
 
-// Htrace is abandoned and has security vulnerabilities.
-val htraceExclusion = ExclusionRule(organization = "org.apache.htrace")
+lazy val forcedExclusions = Seq(
+  // This log4j is abandoned, current has new coordinates
+  ExclusionRule("log4j", "log4j")
+)
+
 lazy val dependencies =
   new {
     val scalatestVersion = "3.2.2"
     val sparkVersion = "2.4.7"
     val jacksonVersion = "2.11.3"
+
+    val log4j = "org.apache.logging.log4j" % "log4j-core" % "2.14.0"
 
     val scalactic = "org.scalactic" %% "scalactic" % scalatestVersion
     val scalatest = "org.scalatest" %% "scalatest" % scalatestVersion

--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,7 @@ lazy val domain = project
       dependencies.sparkSql,
       dependencies.sparkNLP,
       dependencies.sparkMl,
+      dependencies.tensorflow,
       // Handles breaking guava changes https://stackoverflow.com/questions/36427291/illegalaccesserror-to-guavas-stopwatch-from-org-apache-hadoop-mapreduce-lib-inp
       dependencies.hadoopCommon,
       dependencies.apacheCommonsIo
@@ -124,19 +125,21 @@ lazy val dependencies =
     val cats = "org.typelevel" %% "cats-core" % "2.0.0"
 
     val sparkCore =
-      "org.apache.spark" %% "spark-core" % sparkVersion excludeAll (htraceExclusion)
+      "org.apache.spark" %% "spark-core" % sparkVersion
     val sparkSql = "org.apache.spark" %% "spark-sql" % sparkVersion
     val sparkMl =
       "org.apache.spark" %% "spark-mllib" % sparkVersion
     val sparkXml = "com.databricks" %% "spark-xml" % "0.10.0"
+
     val sparkNLP =
-      "com.johnsnowlabs.nlp" %% "spark-nlp" % "2.6.3"
+      "com.johnsnowlabs.nlp" %% "spark-nlp" % "2.6.3" exclude ("org.tensorflow", "tensorflow")
+    val tensorflow = "org.tensorflow" % "tensorflow-core-platform" % "0.2.0"
 
     // Hacks for guava incompatibility
     val hadoopClient =
       "org.apache.hadoop" % "hadoop-mapreduce-client-core" % "2.7.2"
     val hadoopCommon =
-      "org.apache.hadoop" % "hadoop-common" % "2.7.2" // required for org.apache.hadoop.util.StopWatch
+      "org.apache.hadoop" % "hadoop-common" % "2.10.1" // required for org.apache.hadoop.util.StopWatch
     val apacheCommonsIo =
       "commons-io" % "commons-io" % "2.4" // required for org.apache.commons.io.Charsets that is used internally
 

--- a/build.sbt
+++ b/build.sbt
@@ -101,7 +101,8 @@ lazy val forcedDependencies = Seq(
   dependencies.jacksonDatabind,
   dependencies.jacksonCore,
   "org.projectlombok" % "lombok" % "1.18.16",
-  "org.apache.htrace" % "htrace-core" % "4.0.0-incubating"
+  "org.apache.htrace" % "htrace-core" % "4.0.0-incubating",
+  "org.apache.hadoop" % "hadoop-common" % "2.10.1"
 )
 
 lazy val dependencies =

--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,7 @@ lazy val forcedDependencies = Seq(
 lazy val dependencies =
   new {
     val scalatestVersion = "3.2.2"
-    val sparkVersion = "2.4.4"
+    val sparkVersion = "2.4.7"
 
     val scalactic = "org.scalactic" %% "scalactic" % scalatestVersion
     val scalatest = "org.scalatest" %% "scalatest" % scalatestVersion

--- a/build.sbt
+++ b/build.sbt
@@ -16,8 +16,7 @@ lazy val api = project
     settings,
     assemblySettings,
     libraryDependencies ++= commonDependencies ++ playDependencies,
-    dependencyOverrides ++= forcedDependencies,
-    excludeDependencies ++= forcedExclusions
+    dependencyOverrides ++= forcedDependencies
   )
   .dependsOn(domain)
 
@@ -28,8 +27,7 @@ lazy val content = project
     libraryDependencies ++= commonDependencies ++ Seq(
       dependencies.scalatestPlay,
       dependencies.opencc4j
-    ),
-    excludeDependencies ++= forcedExclusions
+    )
   )
   .dependsOn(dto)
 
@@ -59,8 +57,7 @@ lazy val domain = project
       dependencies.hadoopCommon,
       dependencies.apacheCommonsIo
     ),
-    dependencyOverrides ++= forcedDependencies,
-    excludeDependencies ++= forcedExclusions
+    dependencyOverrides ++= forcedDependencies
   )
   .dependsOn(content)
 
@@ -68,8 +65,7 @@ lazy val dto = project
   .settings(
     settings,
     assemblySettings,
-    libraryDependencies ++= commonDependencies,
-    excludeDependencies ++= forcedExclusions
+    libraryDependencies ++= commonDependencies
   )
 
 lazy val jobs = project
@@ -80,13 +76,11 @@ lazy val jobs = project
       dependencies.sparkSql % "provided",
       dependencies.sparkXml
     ),
-    dependencyOverrides ++= forcedDependencies,
-    excludeDependencies ++= forcedExclusions
+    dependencyOverrides ++= forcedDependencies
   )
   .dependsOn(content)
 
 lazy val commonDependencies = Seq(
-//  dependencies.log4j,
   dependencies.scalatest % "test",
   dependencies.scalactic,
   dependencies.cats,
@@ -106,15 +100,10 @@ lazy val forcedDependencies = Seq(
   dependencies.jacksonScala,
   dependencies.jacksonDatabind,
   dependencies.jacksonCore,
-  "org.projectlombok" % "lombok" % "1.18.16",
-  "org.apache.htrace" % "htrace-core" % "4.0.0-incubating",
-  "org.apache.hadoop" % "hadoop-common" % "2.10.1",
-  "org.apache.avro" % "avro" % "1.10.0"
-)
-
-lazy val forcedExclusions = Seq(
-  // This log4j is abandoned, current has new coordinates
-//  ExclusionRule("log4j", "log4j")
+  dependencies.lombok,
+  dependencies.htrace,
+  dependencies.hadoop,
+  dependencies.avro
 )
 
 lazy val dependencies =
@@ -123,8 +112,7 @@ lazy val dependencies =
     val sparkVersion = "2.4.7"
     val jacksonVersion = "2.11.3"
 
-    val log4j = "org.apache.logging.log4j" % "log4j-core" % "2.14.0"
-
+    // Testing
     val scalactic = "org.scalactic" %% "scalactic" % scalatestVersion
     val scalatest = "org.scalatest" %% "scalatest" % scalatestVersion
     val scalatestPlay =
@@ -135,6 +123,7 @@ lazy val dependencies =
 
     val cats = "org.typelevel" %% "cats-core" % "2.0.0"
 
+    // Spark
     val sparkCore =
       "org.apache.spark" %% "spark-core" % sparkVersion
     val sparkSql = "org.apache.spark" %% "spark-sql" % sparkVersion
@@ -142,9 +131,21 @@ lazy val dependencies =
       "org.apache.spark" %% "spark-mllib" % sparkVersion
     val sparkXml = "com.databricks" %% "spark-xml" % "0.10.0"
 
+    // NLP tools
+    val opencc4j = "com.github.houbb" % "opencc4j" % "1.6.0"
     val sparkNLP =
       "com.johnsnowlabs.nlp" %% "spark-nlp" % "2.6.3" exclude ("org.tensorflow", "tensorflow")
     val tensorflow = "org.tensorflow" % "tensorflow-core-platform" % "0.2.0"
+
+    // Graphql
+    val sangria = "org.sangria-graphql" %% "sangria" % "2.0.0"
+    val sangriaPlay = "org.sangria-graphql" %% "sangria-play-json" % "2.0.0"
+
+    // External clients
+    val elasticsearchHighLevelClient =
+      "org.elasticsearch.client" % "elasticsearch-rest-high-level-client" % "7.9.3"
+    val googleCloudClient =
+      "com.google.cloud" % "google-cloud-language" % "1.100.0"
 
     // Hacks for guava incompatibility
     val hadoopClient =
@@ -154,24 +155,17 @@ lazy val dependencies =
     val apacheCommonsIo =
       "commons-io" % "commons-io" % "2.4" // required for org.apache.commons.io.Charsets that is used internally
 
-    val elasticsearchHighLevelClient =
-      "org.elasticsearch.client" % "elasticsearch-rest-high-level-client" % "7.9.3"
-
-    val sangria = "org.sangria-graphql" %% "sangria" % "2.0.0"
-    val sangriaPlay = "org.sangria-graphql" %% "sangria-play-json" % "2.0.0"
-
-    val googleCloudClient =
-      "com.google.cloud" % "google-cloud-language" % "1.100.0"
-
-    // Chinese language processing untilities.
-    val opencc4j = "com.github.houbb" % "opencc4j" % "1.6.0"
-
+    // Security related dependency upgrades below here
     val jacksonScala =
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion
     val jacksonDatabind =
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
     val jacksonCore =
       "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion
+    val lombok = "org.projectlombok" % "lombok" % "1.18.16"
+    val htrace = "org.apache.htrace" % "htrace-core" % "4.0.0-incubating"
+    val hadoop = "org.apache.hadoop" % "hadoop-common" % "2.10.1"
+    val avro = "org.apache.avro" % "avro" % "1.10.0"
   }
 
 lazy val settings = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,7 @@ lazy val jobs = project
   .dependsOn(content)
 
 lazy val commonDependencies = Seq(
-  dependencies.log4j,
+//  dependencies.log4j,
   dependencies.scalatest % "test",
   dependencies.scalactic,
   dependencies.cats,
@@ -114,7 +114,7 @@ lazy val forcedDependencies = Seq(
 
 lazy val forcedExclusions = Seq(
   // This log4j is abandoned, current has new coordinates
-  ExclusionRule("log4j", "log4j")
+//  ExclusionRule("log4j", "log4j")
 )
 
 lazy val dependencies =

--- a/build.sbt
+++ b/build.sbt
@@ -101,7 +101,6 @@ lazy val playDependencies = Seq(
   dependencies.mockito
 )
 
-// Pretty much everything in here is because Spark NLP has versions that conflicts with other dependencies.
 lazy val forcedDependencies = Seq(
   dependencies.hadoopClient,
   dependencies.jacksonScala,
@@ -109,7 +108,8 @@ lazy val forcedDependencies = Seq(
   dependencies.jacksonCore,
   "org.projectlombok" % "lombok" % "1.18.16",
   "org.apache.htrace" % "htrace-core" % "4.0.0-incubating",
-  "org.apache.hadoop" % "hadoop-common" % "2.10.1"
+  "org.apache.hadoop" % "hadoop-common" % "2.10.1",
+  "org.apache.avro" % "avro" % "1.10.0"
 )
 
 lazy val forcedExclusions = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,7 @@
 // Shared
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 
 // Api
 // Workaround for missing npm sources


### PR DESCRIPTION
- Upgrade spark to latest stable 2.4.x
- Ignore htrace vulnerability. It shades a vulnerable jackson version, but does not use code that exposes the vulnerability. Anywhere that handles json or XML is using a newer version.
- Update tensorflow to newer maven coordinates.