### PR TITLE
Upgrade Scala and Play framework October 2020

### DIFF
--- a/.github/workflows/master_codecov.yml
+++ b/.github/workflows/master_codecov.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 8
+    - name: Set up JDK 14
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 14.0.1
     - name: Load SBT cache
       uses: coursier/cache-action@v3
     - name: Compile
@@ -31,7 +31,7 @@ jobs:
       uses: codacy/codacy-coverage-reporter-action@master
       with:
         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-        coverage-reports: api/target/scala-2.11/coverage-report/cobertura.xml, content/target/scala-2.11/coverage-report/cobertura.xml, domain/target/scala-2.11/coverage-report/cobertura.xml, jobs/target/scala-2.11/coverage-report/cobertura.xml
+        coverage-reports: api/target/scala-2.12/coverage-report/cobertura.xml, content/target/scala-2.12/coverage-report/cobertura.xml, domain/target/scala-2.12/coverage-report/cobertura.xml, jobs/target/scala-2.12/coverage-report/cobertura.xml
 
   api:
     runs-on: ubuntu-latest

--- a/.github/workflows/scala_test.yml
+++ b/.github/workflows/scala_test.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 8
+    - name: Set up JDK 14
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 14.0.1
     - name: Load SBT cache
       uses: coursier/cache-action@v3
     - name: Compile
@@ -35,4 +35,4 @@ jobs:
       uses: codacy/codacy-coverage-reporter-action@master
       with:
         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-        coverage-reports: api/target/scala-2.11/coverage-report/cobertura.xml, content/target/scala-2.11/coverage-report/cobertura.xml, domain/target/scala-2.11/coverage-report/cobertura.xml, jobs/target/scala-2.11/coverage-report/cobertura.xml
+        coverage-reports: api/target/scala-2.12/coverage-report/cobertura.xml, content/target/scala-2.12/coverage-report/cobertura.xml, domain/target/scala-2.12/coverage-report/cobertura.xml, jobs/target/scala-2.12/coverage-report/cobertura.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-alpine as builder
+FROM openjdk:14-jdk-alpine3.10 as builder
 MAINTAINER reader@lucaskjaerozhang.com
 
 ENV SBT_VERSION 1.4.0
@@ -26,7 +26,7 @@ RUN unzip /app/api/target/universal/api-0.1.0-SNAPSHOT.zip
 ## Changes to string methods between versions has burned us before
  RUN sbt test
 
-FROM openjdk:8-jdk-alpine as final
+FROM openjdk:14-jdk-alpine3.10 as final
 WORKDIR /app
 RUN apk add bash
 EXPOSE 9000

--- a/build.sbt
+++ b/build.sbt
@@ -46,15 +46,6 @@ lazy val domain = project
       // Clients
       dependencies.opencc4j,
       dependencies.googleCloudClient
-      // Spark NLP
-//      dependencies.sparkCore,
-//      dependencies.sparkSql,
-//      dependencies.sparkNLP,
-//      dependencies.sparkMl,
-//      dependencies.tensorflow,
-//      // Handles breaking guava changes https://stackoverflow.com/questions/36427291/illegalaccesserror-to-guavas-stopwatch-from-org-apache-hadoop-mapreduce-lib-inp
-//      dependencies.hadoopCommon,
-//      dependencies.apacheCommonsIo
     )
   )
   .dependsOn(content)

--- a/build.sbt
+++ b/build.sbt
@@ -105,7 +105,7 @@ lazy val dependencies =
     val scalactic = "org.scalactic" %% "scalactic" % scalatestVersion
     val scalatest = "org.scalatest" %% "scalatest" % scalatestVersion
     val scalatestPlay =
-      "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.0" % Test
+      "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test
     val mockito = "org.mockito" %% "mockito-scala" % "1.16.0" % Test
     val elasticsearchContainer =
       "org.testcontainers" % "elasticsearch" % "1.15.0"

--- a/build.sbt
+++ b/build.sbt
@@ -143,7 +143,7 @@ lazy val dependencies =
     val elasticsearchHighLevelClient =
       "org.elasticsearch.client" % "elasticsearch-rest-high-level-client" % "7.9.3"
     val googleCloudClient =
-      "com.google.cloud" % "google-cloud-language" % "1.100.0"
+      "com.google.cloud" % "google-cloud-language" % "1.101.6"
 
     // Hacks for guava incompatibility
     val hadoopClient =

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "foreign-language-reader-parent"
 organization := "com.foreignlanguagereader"
 version := "1.0-SNAPSHOT"
 
-scalaVersion in ThisBuild := "2.11.12"
+scalaVersion in ThisBuild := "2.13.4"
 
 lazy val global = project
   .in(file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -158,7 +158,8 @@ lazy val compilerOptions = Seq(
   "-deprecation",
   "-feature",
   "-unchecked",
-  "-Xfatal-warnings"
+  "-Xfatal-warnings",
+  "-Ypartial-unification" // Remove me in scala 2.13
 )
 // Add these back in when we can get to scala 2.13
 //  "-Wdead-code",

--- a/build.sbt
+++ b/build.sbt
@@ -116,15 +116,10 @@ lazy val dependencies =
     val sparkCore =
       "org.apache.spark" %% "spark-core" % sparkVersion
     val sparkSql = "org.apache.spark" %% "spark-sql" % sparkVersion
-    val sparkMl =
-      "org.apache.spark" %% "spark-mllib" % sparkVersion
     val sparkXml = "com.databricks" %% "spark-xml" % "0.10.0"
 
     // NLP tools
     val opencc4j = "com.github.houbb" % "opencc4j" % "1.6.0"
-    val sparkNLP =
-      "com.johnsnowlabs.nlp" %% "spark-nlp" % "2.6.3" exclude ("org.tensorflow", "tensorflow")
-    val tensorflow = "org.tensorflow" % "tensorflow-core-platform" % "0.2.0"
 
     // Graphql
     val sangria = "org.sangria-graphql" %% "sangria" % "2.0.0"
@@ -139,10 +134,6 @@ lazy val dependencies =
     // Hacks for guava incompatibility
     val hadoopClient =
       "org.apache.hadoop" % "hadoop-mapreduce-client-core" % "2.7.2"
-    val hadoopCommon =
-      "org.apache.hadoop" % "hadoop-common" % "2.10.1" // required for org.apache.hadoop.util.StopWatch
-    val apacheCommonsIo =
-      "commons-io" % "commons-io" % "2.4" // required for org.apache.commons.io.Charsets that is used internally
 
     // Security related dependency upgrades below here
     val jacksonScala =
@@ -167,8 +158,7 @@ lazy val compilerOptions = Seq(
   "-deprecation",
   "-feature",
   "-unchecked",
-  "-Xfatal-warnings",
-  "-Ypartial-unification" // Remove me in scala 2.13
+  "-Xfatal-warnings"
 )
 // Add these back in when we can get to scala 2.13
 //  "-Wdead-code",

--- a/build.sbt
+++ b/build.sbt
@@ -107,7 +107,7 @@ lazy val forcedDependencies = Seq(
 lazy val dependencies =
   new {
     val scalatestVersion = "3.2.2"
-    val sparkVersion = "2.4.7"
+    val sparkVersion = "3.0.1"
     val jacksonVersion = "2.11.3"
 
     // Testing

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "foreign-language-reader-parent"
 organization := "com.foreignlanguagereader"
 version := "1.0-SNAPSHOT"
 
-scalaVersion in ThisBuild := "2.13.4"
+scalaVersion in ThisBuild := "2.12.12"
 
 lazy val global = project
   .in(file("."))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,6 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 // Api
 // Workaround for missing npm sources
 addSbtPlugin(
-  "com.typesafe.play" % "sbt-plugin" % "2.7.7" exclude ("org.webjars", "npm")
+  "com.typesafe.play" % "sbt-plugin" % "2.8.4" exclude ("org.webjars", "npm")
 )
 libraryDependencies += "org.webjars" % "npm" % "4.2.0"


### PR DESCRIPTION
Increased project versions to the latest possible:
- Java version increased to 14
- Scala version increased to 2.12
- Play framework increased to 2.8
- Spark version increased to 3.0

Scala 2.13 is not supported by spark, so we will hold off at this time.