### PR TITLE
CoreNLP instead of Google Cloud

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN unzip /app/api/target/universal/api-0.1.0-SNAPSHOT.zip
 
 ## Make sure tests are run on the correct JVM
 ## Changes to string methods between versions has burned us before
- RUN sbt test
+RUN sbt test
 
 FROM openjdk:14-jdk-alpine3.10 as final
 WORKDIR /app

--- a/build.sbt
+++ b/build.sbt
@@ -48,6 +48,7 @@ lazy val domain = project
       dependencies.googleCloudClient,
       // NLP
       dependencies.coreNLP,
+      dependencies.coreNLPModels,
       dependencies.coreNLPChinese,
       dependencies.coreNLPEnglish,
       dependencies.coreNLPSpanish
@@ -105,7 +106,7 @@ lazy val dependencies =
     val scalatestVersion = "3.2.2"
     val sparkVersion = "3.0.1"
     val jacksonVersion = "2.11.3"
-    val coreNLPVersion = "4.0.0"
+    val coreNLPVersion = "4.2.0"
 
     // Testing
     val scalactic = "org.scalactic" %% "scalactic" % scalatestVersion
@@ -127,9 +128,14 @@ lazy val dependencies =
     // NLP tools
     val opencc4j = "com.github.houbb" % "opencc4j" % "1.6.0"
     val coreNLP = "edu.stanford.nlp" % "stanford-corenlp" % coreNLPVersion
-    val coreNLPChinese = "edu.stanford.nlp" % "models-chinese" % coreNLPVersion
-    val coreNLPEnglish = "edu.stanford.nlp" % "models-english" % coreNLPVersion
-    val coreNLPSpanish = "edu.stanford.nlp" % "models-spanish" % coreNLPVersion
+    val coreNLPModels =
+      "edu.stanford.nlp" % "stanford-corenlp" % coreNLPVersion classifier "models"
+    val coreNLPChinese =
+      "edu.stanford.nlp" % "stanford-corenlp" % coreNLPVersion classifier "models-chinese"
+    val coreNLPEnglish =
+      "edu.stanford.nlp" % "stanford-corenlp" % coreNLPVersion classifier "models-english"
+    val coreNLPSpanish =
+      "edu.stanford.nlp" % "stanford-corenlp" % coreNLPVersion classifier "models-spanish"
 
     // Graphql
     val sangria = "org.sangria-graphql" %% "sangria" % "2.0.0"

--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,12 @@ lazy val domain = project
       dependencies.elasticsearchContainer,
       // Clients
       dependencies.opencc4j,
-      dependencies.googleCloudClient
+      dependencies.googleCloudClient,
+      // NLP
+      dependencies.coreNLP,
+      dependencies.coreNLPChinese,
+      dependencies.coreNLPEnglish,
+      dependencies.coreNLPSpanish
     )
   )
   .dependsOn(content)
@@ -100,6 +105,7 @@ lazy val dependencies =
     val scalatestVersion = "3.2.2"
     val sparkVersion = "3.0.1"
     val jacksonVersion = "2.11.3"
+    val coreNLPVersion = "4.0.0"
 
     // Testing
     val scalactic = "org.scalactic" %% "scalactic" % scalatestVersion
@@ -120,6 +126,10 @@ lazy val dependencies =
 
     // NLP tools
     val opencc4j = "com.github.houbb" % "opencc4j" % "1.6.0"
+    val coreNLP = "edu.stanford.nlp" % "stanford-corenlp" % coreNLPVersion
+    val coreNLPChinese = "edu.stanford.nlp" % "models-chinese" % coreNLPVersion
+    val coreNLPEnglish = "edu.stanford.nlp" % "models-english" % coreNLPVersion
+    val coreNLPSpanish = "edu.stanford.nlp" % "models-spanish" % coreNLPVersion
 
     // Graphql
     val sangria = "org.sangria-graphql" %% "sangria" % "2.0.0"


### PR DESCRIPTION
Trial of Stanford CoreNLP instead of Google cloud.

Pros:
- We control upgrade times of client libraries. 
- Can be extended to mobile apps if this works well.

Cons:
- Less language support
- We take responsibility for upgrading models.
- Big jar size