### PR TITLE
Guard against automated master commits

### DIFF
--- a/.github/workflows/master_release.yml
+++ b/.github/workflows/master_release.yml
@@ -1,9 +1,9 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - master
+  pull_request:
+    types: [ closed ]
+    branches: master
 
 jobs:
   coverage:


### PR DESCRIPTION
Merging a PR to master bumps the project version, and creates a commit to update the version. This triggers another release. Let's not do that. Now, we create a release only on pull request merge.