### PR TITLE
SBT cache is not in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,5 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 14.0.1
-      - name: Load SBT cache
-        uses: coursier/cache-action@v3
       - name: Publish
         run: sbt release with-defaults


### PR DESCRIPTION
Same reason it's not in baseline workflow -- we don't want to release things that might have changed.